### PR TITLE
Remove null values from responses

### DIFF
--- a/lib/Core/Rpc/ResponseMessage.php
+++ b/lib/Core/Rpc/ResponseMessage.php
@@ -2,9 +2,7 @@
 
 namespace Phpactor\LanguageServer\Core\Rpc;
 
-use JsonSerializable;
-
-class ResponseMessage extends Message implements JsonSerializable
+class ResponseMessage extends Message
 {
     /**
      * @var int|string
@@ -30,20 +28,5 @@ class ResponseMessage extends Message implements JsonSerializable
         $this->id = $id;
         $this->result = $result;
         $this->error = $error;
-    }
-
-    public function jsonSerialize(): array
-    {
-        $response = [
-            'jsonrpc' => $this->jsonrpc,
-            'id' => $this->id,
-            'result' => $this->result,
-        ];
-
-        if (null !== $this->error) {
-            $response['error'] = $this->error;
-        }
-
-        return $response;
     }
 }

--- a/lib/Core/Server/Transmitter/MessageFormatter.php
+++ b/lib/Core/Server/Transmitter/MessageFormatter.php
@@ -9,7 +9,7 @@ final class MessageFormatter
 {
     public function write(Message $message): string
     {
-        $body = json_encode($message);
+        $body = json_encode($this->normalize($message));
 
         if (false === $body) {
             throw new RuntimeException(sprintf(
@@ -28,5 +28,25 @@ final class MessageFormatter
             "\r\n\r\n",
             $body
         ]);
+    }
+
+    /**
+     * Normalize a message before being serialized by recursively applying array_filter.
+     *
+     * @param mixed $message
+     *
+     * @return mixed
+     */
+    private function normalize($message)
+    {
+        if (is_object($message)) {
+            $message = (array) $message;
+        }
+
+        if (!is_array($message)) {
+            return $message;
+        }
+
+        return array_filter(array_map([$this, 'normalize'], $message));
     }
 }

--- a/tests/Unit/Core/Dispatcher/Dispatcher/RecordingDispatcherTest.php
+++ b/tests/Unit/Core/Dispatcher/Dispatcher/RecordingDispatcherTest.php
@@ -50,6 +50,6 @@ class RecordingDispatcherTest extends TestCase
         \Amp\Promise\wait($this->dispatcher->dispatch($handlers, $message, []));
         $this->output->end();
 
-        $this->assertStringContainsString('{"id":1,"method":"hello","params":[],"jsonrpc":"2.0"}', \Amp\Promise\wait($this->output));
+        $this->assertStringContainsString('{"id":1,"method":"hello","jsonrpc":"2.0"}', \Amp\Promise\wait($this->output));
     }
 }

--- a/tests/Unit/Core/Server/Transmitter/MessageFormatterTest.php
+++ b/tests/Unit/Core/Server/Transmitter/MessageFormatterTest.php
@@ -31,11 +31,17 @@ class MessageFormatterTest extends TestCase
             'hello' => 'goodbye'
         ]);
 
-        $result = $writer->write($message);
-        $this->assertEquals(
-            "Content-Type: application/vscode-jsonrpc; charset=utf8\r\nContent-Length: 53\r\n\r\n" . '{"jsonrpc":"2.0","id":1,"result":{"hello":"goodbye"}}',
-            $result
-        );
+        $headers = [
+            'Content-Type: application/vscode-jsonrpc; charset=utf8',
+            'Content-Length: 53',
+        ];
+        $body = [
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'result' => ['hello' => 'goodbye'],
+        ];
+
+        $this->assertMessageContains($headers, $body, $writer->write($message));
     }
 
     public function testWriteErrorReponse()
@@ -45,10 +51,30 @@ class MessageFormatterTest extends TestCase
             'hello' => 'goodbye'
         ], new ResponseError(ErrorCodes::InternalError, 'Sorry'));
 
-        $result = $writer->write($message);
-        $this->assertEquals(
-            "Content-Type: application/vscode-jsonrpc; charset=utf8\r\nContent-Length: 107\r\n\r\n" . '{"jsonrpc":"2.0","id":1,"result":{"hello":"goodbye"},"error":{"code":-32603,"message":"Sorry","data":null}}',
-            $result
-        );
+        $headers = [
+            'Content-Type: application/vscode-jsonrpc; charset=utf8',
+            'Content-Length: 95',
+        ];
+        $body = [
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'result' => ['hello' => 'goodbye'],
+            'error' => ['code' => -32603, 'message' => 'Sorry']
+        ];
+
+        $this->assertMessageContains($headers, $body, $writer->write($message));
+    }
+
+    private function assertMessageContains(
+        array $expectedHeaders,
+        array $expectedBody,
+        string $result
+    ): void {
+        $expectedHeaders = explode("\r\n", $result);
+        $expectedBody = json_decode(array_pop($expectedHeaders), true);
+        array_pop($expectedHeaders); // Remove the separator
+
+        $this->assertEqualsCanonicalizing($expectedHeaders, $expectedHeaders);
+        $this->assertEqualsCanonicalizing($expectedBody, $expectedBody);
     }
 }


### PR DESCRIPTION
We had issues when the response contains null values.
They aren't always handled properly by the clients but it seems that all
clients checks if a nullable key exists or not.
Therefore we might have less issues by simply removing them entirely.