### PR TITLE
Filter null values

### DIFF
--- a/lib/Core/Server/Transmitter/MessageFormatter.php
+++ b/lib/Core/Server/Transmitter/MessageFormatter.php
@@ -3,20 +3,22 @@
 namespace Phpactor\LanguageServer\Core\Server\Transmitter;
 
 use Phpactor\LanguageServer\Core\Rpc\Message;
-use RuntimeException;
 
 final class MessageFormatter
 {
+    /**
+     * @var MessageSerializer
+     */
+    private $serializer;
+
+    public function __construct(?MessageSerializer $serializer = null)
+    {
+        $this->serializer = $serializer ?: new MessageSerializer();
+    }
+
     public function write(Message $message): string
     {
-        $body = json_encode($message);
-
-        if (false === $body) {
-            throw new RuntimeException(sprintf(
-                'Could not encode JSON: "%s"',
-                \json_last_error_msg()
-            ));
-        }
+        $body = $this->serializer->serialize($message);
 
         $headers = [
             'Content-Type: application/vscode-jsonrpc; charset=utf8',

--- a/lib/Core/Server/Transmitter/MessageSerializer.php
+++ b/lib/Core/Server/Transmitter/MessageSerializer.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Phpactor\LanguageServer\Core\Server\Transmitter;
+
+use Phpactor\LanguageServer\Core\Rpc\Message;
+use RuntimeException;
+
+class MessageSerializer
+{
+    public function serialize(Message $message): string
+    {
+        $decoded = json_encode($this->normalize($message));
+
+        if (false === $decoded) {
+            throw new RuntimeException(sprintf(
+                'Could not encode JSON: "%s"',
+                \json_last_error_msg()
+            ));
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * Normalize a message before being serialized by recursively applying array_filter
+     * and removing null values
+     *
+     * @param mixed $message
+     *
+     * @return mixed
+     */
+    private function normalize($message)
+    {
+        if (is_object($message)) {
+            $message = (array) $message;
+        }
+
+        if (!is_array($message)) {
+            return $message;
+        }
+
+        return array_filter(array_map([$this, 'normalize'], $message), function ($value) {
+            return $value !== null;
+        });
+    }
+}

--- a/tests/Unit/Core/Server/Transmitter/MessageSerializerTest.php
+++ b/tests/Unit/Core/Server/Transmitter/MessageSerializerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Phpactor\LanguageServer\Tests\Unit\Core\Server\Transmitter;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\LanguageServer\Core\Rpc\Message;
+use Phpactor\LanguageServer\Core\Rpc\NotificationMessage;
+use Phpactor\LanguageServer\Core\Rpc\ResponseError;
+use Phpactor\LanguageServer\Core\Rpc\ResponseMessage;
+use Phpactor\LanguageServer\Core\Server\Transmitter\MessageSerializer;
+use RuntimeException;
+
+class MessageSerializerTest extends TestCase
+{
+    public function testExceptionCouldNotEncodeJson()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not encode JSON');
+
+        $message = new ResponseMessage(1, [
+            'hello' => \fopen('php://stdin', 'r')
+        ]);
+
+        $this->serialize($message);
+    }
+
+    /**
+     * @dataProvider provideSerializes
+     */
+    public function testSerializes(Message $message, string $expected)
+    {
+        self::assertEquals($expected, $this->serialize($message));
+    }
+
+    public function provideSerializes()
+    {
+        yield 'response message' => [
+            new ResponseMessage(1, [], new ResponseError(1, 'foobar', [])),
+            '{"id":1,"result":[],"error":{"code":1,"message":"foobar","data":[]},"jsonrpc":"2.0"}',
+        ];
+
+        yield 'preserves falsey values' => [
+            new ResponseMessage(0, ''),
+            '{"id":0,"result":"","jsonrpc":"2.0"}',
+        ];
+
+        yield 'removes nested null' => [
+            new NotificationMessage('showMessage', [
+                'foobar' => [
+                    'notnull' => 'notnull',
+                    'null' => null,
+                ],
+            ]),
+            '{"method":"showMessage","params":{"foobar":{"notnull":"notnull"}},"jsonrpc":"2.0"}',
+        ];
+    }
+
+    private function serialize(Message $message): string
+    {
+        return (new MessageSerializer())->serialize($message);
+    }
+}


### PR DESCRIPTION
Ensure that null values are removed from the serialized message.

@elythyr this builds on your PR - the issue was actually that `array_filter` usees `falsey` by default -- my mistake. I took the opportunity to separate serialization from formatting the message.