### PR TITLE
Handle progress messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /.vscode
 .php_cs.cache
 .phpunit.result.cache
+.php-cs-fixer.cache

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /doc/_build
 /.vscode
 .php_cs.cache
+.phpunit.result.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -8,7 +8,7 @@ $finder = PhpCsFixer\Finder::create()
     ])
 ;
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
         '@PSR2' => true,

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "amphp/phpunit-util": "^1.3",
         "ergebnis/composer-normalize": "^2.0",
-        "friendsofphp/php-cs-fixer": "^2.17",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "jangregor/phpstan-prophecy": "^0.8.0",
         "phpactor/phly-event-dispatcher": "~2.0.0",
         "phpactor/test-utils": "~1.1.3",

--- a/lib/Core/Server/Client/WorkDoneProgressClient.php
+++ b/lib/Core/Server/Client/WorkDoneProgressClient.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Phpactor\LanguageServer\Core\Server\Client;
+
+use Amp\Promise;
+use InvalidArgumentException;
+use Phpactor\LanguageServer\Core\Rpc\ResponseMessage;
+use Phpactor\LanguageServer\Core\Server\RpcClient;
+
+final class WorkDoneProgressClient
+{
+    /**
+     * @var RpcClient
+     */
+    private $client;
+
+    public function __construct(RpcClient $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * @return Promise<ResponseMessage>
+     */
+    public function create(string $token): Promise
+    {
+        return \Amp\call(function () use ($token) {
+            return yield $this->client->request('window/workDoneProgress/create', [
+                'token' => $token,
+            ]);
+        });
+    }
+
+    public function begin(
+        string $token,
+        string $title,
+        ?string $message = null,
+        ?int $percentage = null,
+        ?bool $cancellable = null
+    ): void {
+        self::assertIsValidPercentage($percentage);
+
+        $this->notify($token, [
+            'kind' => 'begin',
+            'title' => $title,
+            'message' => $message,
+            'percentage' => $percentage,
+            'cancellable' => $cancellable,
+        ]);
+    }
+
+    public function report(
+        string $token,
+        ?string $message = null,
+        ?int $percentage = null,
+        ?bool $cancellable = null
+    ): void {
+        self::assertIsValidPercentage($percentage);
+
+        $this->notify($token, [
+            'kind' => 'report',
+            'message' => $message,
+            'percentage' => $percentage,
+            'cancellable' => $cancellable,
+        ]);
+    }
+
+    public function end(string $token, ?string $message = null): void
+    {
+        $this->notify($token, [
+            'kind' => 'end',
+            'message' => $message,
+        ]);
+    }
+
+    private static function assertIsValidPercentage(?int $percentage): void
+    {
+        if (!(null === $percentage || 0 <= $percentage && $percentage <= 100)) {
+            throw new InvalidArgumentException(
+                'The percentage must be an integer comprised between 0 and 100.',
+            );
+        }
+    }
+
+    private function notify(string $token, array $value): void
+    {
+        assert(in_array($value['kind'], ['begin', 'report', 'end']));
+
+        $this->client->notification('$/progress', [
+            'token' => $token,
+            'value' => $value,
+        ]);
+    }
+}

--- a/lib/Core/Server/Client/WorkDoneProgressClient.php
+++ b/lib/Core/Server/Client/WorkDoneProgressClient.php
@@ -6,6 +6,7 @@ use Amp\Promise;
 use InvalidArgumentException;
 use Phpactor\LanguageServer\Core\Rpc\ResponseMessage;
 use Phpactor\LanguageServer\Core\Server\RpcClient;
+use Phpactor\LanguageServer\WorkDoneProgress\WorkDoneToken;
 
 final class WorkDoneProgressClient
 {
@@ -22,17 +23,17 @@ final class WorkDoneProgressClient
     /**
      * @return Promise<ResponseMessage>
      */
-    public function create(string $token): Promise
+    public function create(WorkDoneToken $token): Promise
     {
         return \Amp\call(function () use ($token) {
             return yield $this->client->request('window/workDoneProgress/create', [
-                'token' => $token,
+                'token' => (string) $token,
             ]);
         });
     }
 
     public function begin(
-        string $token,
+        WorkDoneToken $token,
         string $title,
         ?string $message = null,
         ?int $percentage = null,
@@ -50,7 +51,7 @@ final class WorkDoneProgressClient
     }
 
     public function report(
-        string $token,
+        WorkDoneToken $token,
         ?string $message = null,
         ?int $percentage = null,
         ?bool $cancellable = null
@@ -65,7 +66,7 @@ final class WorkDoneProgressClient
         ]);
     }
 
-    public function end(string $token, ?string $message = null): void
+    public function end(WorkDoneToken $token, ?string $message = null): void
     {
         $this->notify($token, [
             'kind' => 'end',
@@ -82,12 +83,12 @@ final class WorkDoneProgressClient
         }
     }
 
-    private function notify(string $token, array $value): void
+    private function notify(WorkDoneToken $token, array $value): void
     {
         assert(in_array($value['kind'], ['begin', 'report', 'end']));
 
         $this->client->notification('$/progress', [
-            'token' => $token,
+            'token' => (string) $token,
             'value' => $value,
         ]);
     }

--- a/lib/Core/Server/ClientApi.php
+++ b/lib/Core/Server/ClientApi.php
@@ -5,6 +5,7 @@ namespace Phpactor\LanguageServer\Core\Server;
 use Phpactor\LanguageServer\Core\Server\Client\ClientClient;
 use Phpactor\LanguageServer\Core\Server\Client\DiagnosticsClient;
 use Phpactor\LanguageServer\Core\Server\Client\WindowClient;
+use Phpactor\LanguageServer\Core\Server\Client\WorkDoneProgressClient;
 use Phpactor\LanguageServer\Core\Server\Client\WorkspaceClient;
 
 final class ClientApi
@@ -37,5 +38,10 @@ final class ClientApi
     public function diagnostics(): DiagnosticsClient
     {
         return new DiagnosticsClient($this->client);
+    }
+
+    public function workDoneProgress(): WorkDoneProgressClient
+    {
+        return new WorkDoneProgressClient($this->client);
     }
 }

--- a/lib/Core/Server/RpcClient/TestRpcClient.php
+++ b/lib/Core/Server/RpcClient/TestRpcClient.php
@@ -3,7 +3,6 @@
 namespace Phpactor\LanguageServer\Core\Server\RpcClient;
 
 use Amp\Promise;
-use Phpactor\LanguageServer\Core\Server\ResponseWatcher;
 use Phpactor\LanguageServer\Core\Server\ResponseWatcher\TestResponseWatcher;
 use Phpactor\LanguageServer\Core\Server\RpcClient;
 use Phpactor\LanguageServer\Core\Server\Transmitter\TestMessageTransmitter;

--- a/lib/WorkDoneProgress/ClientCapabilityDependentProgressNotifier.php
+++ b/lib/WorkDoneProgress/ClientCapabilityDependentProgressNotifier.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Phpactor\LanguageServer\WorkDoneProgress;
+
+use Amp\Promise;
+use Phpactor\LanguageServerProtocol\ClientCapabilities;
+use Phpactor\LanguageServer\Core\Server\ClientApi;
+
+final class ClientCapabilityDependentProgressNotifier implements ProgressNotifier
+{
+    /**
+     * @var ProgressNotifier
+     */
+    private $notifier;
+
+    public function __construct(ClientApi $api, ClientCapabilities $capabilities)
+    {
+        if ($capabilities->window['workDoneProgress'] ?? false) {
+            $this->notifier = new WorkDoneProgressNotifier($api);
+        } else {
+            $this->notifier = new MessageProgressNotifier($api);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function create(WorkDoneToken $token): Promise
+    {
+        return $this->notifier->create($token);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function begin(
+        WorkDoneToken $token,
+        string $title,
+        ?string $message = null,
+        ?int $percentage = null,
+        ?bool $cancellable = null
+    ): void {
+        $this->notifier->begin($token, $title, $message, $percentage, $cancellable);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function report(
+        WorkDoneToken $token,
+        ?string $message = null,
+        ?int $percentage = null,
+        ?bool $cancellable = null
+    ): void {
+        $this->notifier->report($token, $message, $percentage, $cancellable);
+    }
+
+    public function end(WorkDoneToken $token, ?string $message = null): void
+    {
+        $this->notifier->end($token, $message);
+    }
+}

--- a/lib/WorkDoneProgress/MessageProgressNotifier.php
+++ b/lib/WorkDoneProgress/MessageProgressNotifier.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Phpactor\LanguageServer\WorkDoneProgress;
+
+use Amp\Promise;
+use Amp\Success;
+use Phpactor\LanguageServer\Core\Rpc\ResponseMessage;
+use Phpactor\LanguageServer\Core\Server\ClientApi;
+use Phpactor\LanguageServer\Core\Server\Client\MessageClient;
+use Ramsey\Uuid\Uuid;
+
+final class MessageProgressNotifier implements ProgressNotifier
+{
+    /**
+     * @var MessageClient
+     */
+    private $api;
+
+    public function __construct(ClientApi $api)
+    {
+        $this->api = $api->window()->showMessage();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function create(WorkDoneToken $token): Promise
+    {
+        return new Success(new ResponseMessage(
+            Uuid::uuid4(),
+            null,
+        ));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function begin(
+        WorkDoneToken $token,
+        string $title,
+        ?string $message = null,
+        ?int $percentage = null,
+        ?bool $cancellable = null
+    ): void {
+        $this->api->info($message);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function report(WorkDoneToken $token, ?string $message = null, ?int $percentage = null, ?bool $cancellable = null): void
+    {
+        $this->api->info(sprintf('%s - %d%%', $message, $percentage));
+    }
+
+    public function end(WorkDoneToken $token, ?string $message = null): void
+    {
+        $this->api->info($message);
+    }
+}

--- a/lib/WorkDoneProgress/ProgressNotifier.php
+++ b/lib/WorkDoneProgress/ProgressNotifier.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Phpactor\LanguageServer\WorkDoneProgress;
+
+use Amp\Promise;
+use Phpactor\LanguageServer\Core\Rpc\ResponseMessage;
+
+interface ProgressNotifier
+{
+    /**
+     * @return Promise<ResponseMessage>
+     */
+    public function create(WorkDoneToken $token): Promise;
+
+    /**
+     * @param int|null $percentage Percentage comprised between 0 and 100
+     */
+    public function begin(
+        WorkDoneToken $token,
+        string $title,
+        ?string $message = null,
+        ?int $percentage = null,
+        ?bool $cancellable = null
+    ): void;
+
+    /**
+     * @param int|null $percentage Percentage comprised between 0 and 100
+     */
+    public function report(
+        WorkDoneToken $token,
+        ?string $message = null,
+        ?int $percentage = null,
+        ?bool $cancellable = null
+    ): void;
+
+    public function end(WorkDoneToken $token, ?string $message = null): void;
+}

--- a/lib/WorkDoneProgress/WorkDoneProgressNotifier.php
+++ b/lib/WorkDoneProgress/WorkDoneProgressNotifier.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Phpactor\LanguageServer\WorkDoneProgress;
+
+use Amp\Promise;
+use Phpactor\LanguageServer\Core\Server\ClientApi;
+use Phpactor\LanguageServer\Core\Server\Client\WorkDoneProgressClient;
+
+final class WorkDoneProgressNotifier implements ProgressNotifier
+{
+    /**
+     * @var WorkDoneProgressClient
+     */
+    private $api;
+
+    public function __construct(ClientApi $api)
+    {
+        $this->api = $api->workDoneProgress();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function create(WorkDoneToken $token): Promise
+    {
+        return $this->api->create($token);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function begin(
+        WorkDoneToken $token,
+        string $title,
+        ?string $message = null,
+        ?int $percentage = null,
+        ?bool $cancellable = null
+    ): void {
+        $this->api->begin($token, $title, $message, $percentage, $cancellable);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function report(
+        WorkDoneToken $token,
+        ?string $message = null,
+        ?int $percentage = null,
+        ?bool $cancellable = null
+    ): void {
+        $this->api->report($token, $message, $percentage, $cancellable);
+    }
+
+    public function end(WorkDoneToken $token, ?string $message = null): void
+    {
+        $this->api->end($token, $message);
+    }
+}

--- a/lib/WorkDoneProgress/WorkDoneToken.php
+++ b/lib/WorkDoneProgress/WorkDoneToken.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Phpactor\LanguageServer\WorkDoneProgress;
+
+use Ramsey\Uuid\Uuid;
+
+final class WorkDoneToken
+{
+    /**
+     * @var string
+     */
+    private $token;
+
+    public function __construct(string $token)
+    {
+        $this->token = $token;
+    }
+
+    public function __toString(): string
+    {
+        return $this->token;
+    }
+
+    public static function generate(): self
+    {
+        return new self((string) Uuid::uuid4());
+    }
+}

--- a/tests/Unit/Core/Server/ClientApiTest.php
+++ b/tests/Unit/Core/Server/ClientApiTest.php
@@ -26,6 +26,7 @@ class ClientApiTest extends AsyncTestCase
      * @dataProvider provideWorkspaceExecuteCommand
      * @dataProvider provideDiagnostics
      * @dataProvider provideRegisterCapability
+     * @dataProvider provideWorkDoneProgress
      */
     public function testSend(Closure $executor, Closure $assertions): void
     {
@@ -37,7 +38,7 @@ class ClientApiTest extends AsyncTestCase
     }
 
     /**
-     * @reuturn Generator<mixed>
+     * @return Generator<mixed>
      */
     public function provideWindowShowMessage(): Generator
     {
@@ -70,7 +71,7 @@ class ClientApiTest extends AsyncTestCase
     }
 
     /**
-     * @reuturn Generator<mixed>
+     * @return Generator<mixed>
      */
     public function provideWindowLogMessage(): Generator
     {
@@ -103,7 +104,7 @@ class ClientApiTest extends AsyncTestCase
     }
 
     /**
-     * @reuturn Generator<mixed>
+     * @return Generator<mixed>
      */
     public function provideWindowShowMessageRequest(): Generator
     {
@@ -126,7 +127,7 @@ class ClientApiTest extends AsyncTestCase
     }
 
     /**
-     * @reuturn Generator<mixed>
+     * @return Generator<mixed>
      */
     public function provideWorkspaceEdit(): Generator
     {
@@ -151,7 +152,7 @@ class ClientApiTest extends AsyncTestCase
     }
 
     /**
-     * @reuturn Generator<mixed>
+     * @return Generator<mixed>
      */
     public function provideWorkspaceExecuteCommand(): Generator
     {
@@ -171,7 +172,7 @@ class ClientApiTest extends AsyncTestCase
     }
 
     /**
-     * @reuturn Generator<mixed>
+     * @return Generator<mixed>
      */
     public function provideDiagnostics(): Generator
     {
@@ -192,7 +193,7 @@ class ClientApiTest extends AsyncTestCase
     }
 
     /**
-     * @reuturn Generator<mixed>
+     * @return Generator<mixed>
      */
     public function provideRegisterCapability(): Generator
     {
@@ -219,6 +220,78 @@ class ClientApiTest extends AsyncTestCase
             function (TestRpcClient $client, $result): void {
                 $message = $client->transmitter()->shiftRequest();
                 self::assertEquals('client/unregisterCapability', $message->method);
+            }
+        ];
+    }
+
+    /**
+     * @return Generator<mixed>
+     */
+    public function provideWorkDoneProgress(): Generator
+    {
+        yield 'Creating Work Done Progress' => [
+            function (ClientApi $api): void {
+                $api->workDoneProgress()->create('4ef439b3-3c6a-4c98-ae0a-af2b4503cb15');
+            },
+            function (TestRpcClient $client): void {
+                $message = $client->transmitter()->shiftRequest();
+                self::assertEquals('window/workDoneProgress/create', $message->method);
+                self::assertEquals('4ef439b3-3c6a-4c98-ae0a-af2b4503cb15', $message->params['token']);
+            }
+        ];
+
+        yield 'Work Done Progress Begin' => [
+            function (ClientApi $api): void {
+                $api->workDoneProgress()->begin(
+                    '4ef439b3-3c6a-4c98-ae0a-af2b4503cb15',
+                    'title',
+                    'message',
+                );
+            },
+            function (TestRpcClient $client, $result): void {
+                $message = $client->transmitter()->shiftNotification();
+                self::assertEquals('$/progress', $message->method);
+                self::assertEquals('4ef439b3-3c6a-4c98-ae0a-af2b4503cb15', $message->params['token']);
+                self::assertEquals('begin', $message->params['value']['kind']);
+                self::assertEquals('title', $message->params['value']['title']);
+                self::assertEquals('message', $message->params['value']['message']);
+                self::assertNull($message->params['value']['percentage']);
+                self::assertNull($message->params['value']['cancellable']);
+            }
+        ];
+
+        yield 'Work Done Progress Report' => [
+            function (ClientApi $api): void {
+                $api->workDoneProgress()->report(
+                    '4ef439b3-3c6a-4c98-ae0a-af2b4503cb15',
+                    'message',
+                    20,
+                );
+            },
+            function (TestRpcClient $client, $result): void {
+                $message = $client->transmitter()->shiftNotification();
+                self::assertEquals('$/progress', $message->method);
+                self::assertEquals('4ef439b3-3c6a-4c98-ae0a-af2b4503cb15', $message->params['token']);
+                self::assertEquals('report', $message->params['value']['kind']);
+                self::assertEquals('message', $message->params['value']['message']);
+                self::assertEquals(20, $message->params['value']['percentage']);
+                self::assertNull($message->params['value']['cancellable']);
+            }
+        ];
+
+        yield 'Work Done Progress End' => [
+            function (ClientApi $api): void {
+                $api->workDoneProgress()->end(
+                    '4ef439b3-3c6a-4c98-ae0a-af2b4503cb15',
+                    'message',
+                );
+            },
+            function (TestRpcClient $client, $result): void {
+                $message = $client->transmitter()->shiftNotification();
+                self::assertEquals('$/progress', $message->method);
+                self::assertEquals('4ef439b3-3c6a-4c98-ae0a-af2b4503cb15', $message->params['token']);
+                self::assertEquals('end', $message->params['value']['kind']);
+                self::assertEquals('message', $message->params['value']['message']);
             }
         ];
     }

--- a/tests/Unit/Core/Server/ClientApiTest.php
+++ b/tests/Unit/Core/Server/ClientApiTest.php
@@ -15,6 +15,7 @@ use Phpactor\LanguageServerProtocol\Unregistration;
 use Phpactor\LanguageServerProtocol\WorkspaceEdit;
 use Phpactor\LanguageServer\Core\Server\ClientApi;
 use Phpactor\LanguageServer\Core\Server\RpcClient\TestRpcClient;
+use Phpactor\LanguageServer\WorkDoneProgress\WorkDoneToken;
 
 class ClientApiTest extends AsyncTestCase
 {
@@ -231,7 +232,8 @@ class ClientApiTest extends AsyncTestCase
     {
         yield 'Creating Work Done Progress' => [
             function (ClientApi $api): void {
-                $api->workDoneProgress()->create('4ef439b3-3c6a-4c98-ae0a-af2b4503cb15');
+                $token = new WorkDoneToken('4ef439b3-3c6a-4c98-ae0a-af2b4503cb15');
+                $api->workDoneProgress()->create($token);
             },
             function (TestRpcClient $client): void {
                 $message = $client->transmitter()->shiftRequest();
@@ -242,11 +244,8 @@ class ClientApiTest extends AsyncTestCase
 
         yield 'Work Done Progress Begin' => [
             function (ClientApi $api): void {
-                $api->workDoneProgress()->begin(
-                    '4ef439b3-3c6a-4c98-ae0a-af2b4503cb15',
-                    'title',
-                    'message',
-                );
+                $token = new WorkDoneToken('4ef439b3-3c6a-4c98-ae0a-af2b4503cb15');
+                $api->workDoneProgress()->begin($token, 'title', 'message');
             },
             function (TestRpcClient $client, $result): void {
                 $message = $client->transmitter()->shiftNotification();
@@ -262,11 +261,8 @@ class ClientApiTest extends AsyncTestCase
 
         yield 'Work Done Progress Report' => [
             function (ClientApi $api): void {
-                $api->workDoneProgress()->report(
-                    '4ef439b3-3c6a-4c98-ae0a-af2b4503cb15',
-                    'message',
-                    20,
-                );
+                $token = new WorkDoneToken('4ef439b3-3c6a-4c98-ae0a-af2b4503cb15');
+                $api->workDoneProgress()->report($token, 'message', 20);
             },
             function (TestRpcClient $client, $result): void {
                 $message = $client->transmitter()->shiftNotification();
@@ -281,10 +277,8 @@ class ClientApiTest extends AsyncTestCase
 
         yield 'Work Done Progress End' => [
             function (ClientApi $api): void {
-                $api->workDoneProgress()->end(
-                    '4ef439b3-3c6a-4c98-ae0a-af2b4503cb15',
-                    'message',
-                );
+                $token = new WorkDoneToken('4ef439b3-3c6a-4c98-ae0a-af2b4503cb15');
+                $api->workDoneProgress()->end($token, 'message');
             },
             function (TestRpcClient $client, $result): void {
                 $message = $client->transmitter()->shiftNotification();

--- a/tests/Unit/WorkDoneProgress/ClientCapabilityDependentProgressNotifierTest.php
+++ b/tests/Unit/WorkDoneProgress/ClientCapabilityDependentProgressNotifierTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Phpactor\LanguageServer\Tests\Unit\WorkDoneProgress;
+
+use Amp\PHPUnit\AsyncTestCase;
+use Phpactor\LanguageServerProtocol\ClientCapabilities;
+use Phpactor\LanguageServerProtocol\MessageType;
+use Phpactor\LanguageServer\Core\Server\ClientApi;
+use Phpactor\LanguageServer\Core\Server\RpcClient\TestRpcClient;
+use Phpactor\LanguageServer\Core\Server\Transmitter\TestMessageTransmitter;
+use Phpactor\LanguageServer\WorkDoneProgress\ClientCapabilityDependentProgressNotifier;
+use Phpactor\LanguageServer\WorkDoneProgress\WorkDoneToken;
+
+final class ClientCapabilityDependentProgressNotifierTest extends AsyncTestCase
+{
+    /**
+     * @var TestRpcClient
+     */
+    private $client;
+
+    /**
+     * @var TestMessageTransmitter
+     */
+    private $transmitter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->client = TestRpcClient::create();
+        $this->transmitter = $this->client->transmitter();
+    }
+
+    public function testNotifyWithWorkDoneProgressCapability(): void
+    {
+        $token = WorkDoneToken::generate();
+        $notifier = $this->createNotifierWithProgressCapability();
+
+        $notifier->create($token);
+        $message = $this->transmitter->shiftRequest();
+        $this->assertEquals('window/workDoneProgress/create', $message->method);
+        $this->assertEquals((string) $token, $message->params['token']);
+
+        $notifier->begin($token, 'title', 'begin message');
+        $message = $this->transmitter->shiftNotification();
+        $this->assertEquals('$/progress', $message->method);
+        $this->assertEquals((string) $token, $message->params['token']);
+        $this->assertEquals('begin', $message->params['value']['kind']);
+        $this->assertEquals('title', $message->params['value']['title']);
+        $this->assertEquals('begin message', $message->params['value']['message']);
+        $this->assertNull($message->params['value']['percentage']);
+        $this->assertNull($message->params['value']['cancellable']);
+
+        $notifier->report($token, 'report message', 30);
+        $message = $this->transmitter->shiftNotification();
+        $this->assertEquals('$/progress', $message->method);
+        $this->assertEquals((string) $token, $message->params['token']);
+        $this->assertEquals('report', $message->params['value']['kind']);
+        $this->assertEquals('report message', $message->params['value']['message']);
+        $this->assertEquals(30, $message->params['value']['percentage']);
+        $this->assertNull($message->params['value']['cancellable']);
+
+        $notifier->end($token, 'end message');
+        $message = $this->transmitter->shiftNotification();
+        $this->assertEquals('$/progress', $message->method);
+        $this->assertEquals((string) $token, $message->params['token']);
+        $this->assertEquals('end', $message->params['value']['kind']);
+        $this->assertEquals('end message', $message->params['value']['message']);
+    }
+
+    public function testNotifyWithoutWorkDoneProgressCapability(): void
+    {
+        $token = WorkDoneToken::generate();
+        $notifier = $this->createNotifierWithoutProgressCapability();
+
+        $notifier->create($token);
+        $message = $this->transmitter->shiftNotification();
+        $this->assertNull($message); // Fake response so no message sent
+
+        $notifier->begin($token, 'title', 'begin message');
+        $message = $this->transmitter->shiftNotification();
+        $this->assertEquals('window/showMessage', $message->method);
+        $this->assertEquals(MessageType::INFO, $message->params['type']);
+        $this->assertEquals('begin message', $message->params['message']);
+
+        $notifier->report($token, 'report message', 30);
+        $message = $this->transmitter->shiftNotification();
+        $this->assertEquals('window/showMessage', $message->method);
+        $this->assertEquals(MessageType::INFO, $message->params['type']);
+        $this->assertEquals('report message - 30%', $message->params['message']);
+
+        $notifier->end($token, 'end message');
+        $message = $this->transmitter->shiftNotification();
+        $this->assertEquals('window/showMessage', $message->method);
+        $this->assertEquals(MessageType::INFO, $message->params['type']);
+        $this->assertEquals('end message', $message->params['message']);
+    }
+
+    private function createNotifierWithProgressCapability() : ClientCapabilityDependentProgressNotifier
+    {
+        return $this->createNotifier(true);
+    }
+
+    private function createNotifierWithoutProgressCapability() : ClientCapabilityDependentProgressNotifier
+    {
+        return $this->createNotifier(false);
+    }
+
+    private function createNotifier(bool $WorkDoneProgress) : ClientCapabilityDependentProgressNotifier
+    {
+        $api = new ClientApi($this->client);
+        $capabilities = ClientCapabilities::fromArray([
+            'window' => ['workDoneProgress' => $WorkDoneProgress],
+        ]);
+
+        return new ClientCapabilityDependentProgressNotifier($api, $capabilities);
+    }
+}


### PR DESCRIPTION
Hi there,

It's been a long time since have participated, I finally managed to free some of it so I'll try to catch up :smile: 
Switching to Neovim builtin LSP I realized that we don't handle the progress notification.

This PR provide a first basic implementation and I would have liked your feedback opinion on different points:

[Server initiated progress](https://microsoft.github.io/language-server-protocol/specification.html#serverInitiatedProgress)

> A token obtained using the create request should only be used once (e.g. only one begin, many report and one end notification should be sent to it).

I had the idea of adding a `WorkDoneProgressTracker` to follow the different progresses and be able to throw errors if we try to reuse a token but I wonder if it's not a bit "much".
In addition it forces us to keep track of the different tokens and their state which might at some point begin to be a memory issue during long sessions so we will also have to deal with the cleanup of old tokens...

I wonder if it would be interesting to provide a helper class for progress notification, which goal would be to either use the `$/progress` ou `window/showMessage` depending on the client capabilities.
This way we can keep sending progress to the client even if it does not handle `$/progress` and we don't have to duplicate the logic every where.
If so, how could I retrieve the client capabilities ?
I remember back in the days we talked about some kind of "capabilities provider" that we could inject but I think we ended up injecting the capabilities required by a service directly instead ?
How would you see this helper, as a standalone service with a dependency on the `ClientApi` and capability or as a "custom" client inside the `ClientApi` in which we inject the capability and gave the responsibility to instantiate the helper ?