### PR TITLE
 Fix #1304 - Dynamic registration only if supported

### DIFF
--- a/bin/serve.php
+++ b/bin/serve.php
@@ -110,7 +110,7 @@ $builder = LanguageServerBuilder::create(new ClosureDispatcherFactory(
         $eventDispatcher = new AggregateEventDispatcher(
             new ServiceListener($serviceManager),
             new WorkspaceListener($workspace),
-            new DidChangeWatchedFilesListener($clientApi, ['**/*.php']),
+            new DidChangeWatchedFilesListener($clientApi, ['**/*.php'], $params->capabilities),
             $diagnosticsService
         );
 

--- a/lib/Core/Command/ClosureCommand.php
+++ b/lib/Core/Command/ClosureCommand.php
@@ -20,7 +20,8 @@ class ClosureCommand implements Command
      * @param mixed[] $args
      * @return mixed
      */
-    public function __invoke(...$args) {
+    public function __invoke(...$args)
+    {
         $closure = $this->closure;
         return $closure(...$args);
     }

--- a/lib/LanguageServerTesterBuilder.php
+++ b/lib/LanguageServerTesterBuilder.php
@@ -341,7 +341,7 @@ final class LanguageServerTesterBuilder
                 }
 
                 if ($this->enableFileEvents) {
-                    $this->listeners[] = new DidChangeWatchedFilesListener($this->clientApi, $this->fileEventGlobs);
+                    $this->listeners[] = new DidChangeWatchedFilesListener($this->clientApi, $this->fileEventGlobs, $params->capabilities);
                 }
 
                 $serviceManager = new ServiceManager(new ServiceProviders(...$serviceProviders), $logger);

--- a/lib/Listener/DidChangeWatchedFilesListener.php
+++ b/lib/Listener/DidChangeWatchedFilesListener.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\LanguageServer\Listener;
 
+use Phpactor\LanguageServerProtocol\ClientCapabilities;
 use Phpactor\LanguageServerProtocol\DidChangeWatchedFilesRegistrationOptions;
 use Phpactor\LanguageServerProtocol\FileSystemWatcher;
 use Phpactor\LanguageServerProtocol\Registration;
@@ -23,10 +24,16 @@ class DidChangeWatchedFilesListener implements ListenerProviderInterface
      */
     private $globPatterns;
 
-    public function __construct(ClientApi $client, array $globPatterns)
+    /**
+     * @var ClientCapabilities
+     */
+    private $clientCapabilities;
+
+    public function __construct(ClientApi $client, array $globPatterns, ClientCapabilities $clientCapabilities)
     {
         $this->client = $client;
         $this->globPatterns = $globPatterns;
+        $this->clientCapabilities = $clientCapabilities;
     }
 
     /**
@@ -43,6 +50,10 @@ class DidChangeWatchedFilesListener implements ListenerProviderInterface
 
     public function registerCapability(Initialized $initialized): void
     {
+        if (!($this->clientCapabilities->workspace['didChangeWatchedFiles']['dynamicRegistration'] ?? false)) {
+            return;
+        }
+
         asyncCall(function () {
             yield $this->client->client()->registerCapability(
                 new Registration(

--- a/tests/Unit/Listener/DidChangeWatchedFilesListenerTest.php
+++ b/tests/Unit/Listener/DidChangeWatchedFilesListenerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Phpactor\LanguageServer\Tests\Unit\Listener;
+
+use Phpactor\LanguageServerProtocol\ClientCapabilities;
+use Phpactor\LanguageServerProtocol\DidChangeWatchedFilesRegistrationOptions;
+use Phpactor\LanguageServerProtocol\FileSystemWatcher;
+use Phpactor\LanguageServerProtocol\Registration;
+use Phpactor\LanguageServer\Core\Server\ClientApi;
+use Phpactor\LanguageServer\Core\Server\RpcClient\TestRpcClient;
+use Phpactor\LanguageServer\Core\Server\Transmitter\TestMessageTransmitter;
+use Phpactor\LanguageServer\Event\Initialized;
+use Phpactor\LanguageServer\Listener\DidChangeWatchedFilesListener;
+use Phpactor\TestUtils\PHPUnit\TestCase;
+
+class DidChangeWatchedFilesListenerTest extends TestCase
+{
+    /**
+     * @var DidChangeWatchedFilesListener
+     */
+    private $listener;
+
+    /**
+     * @var TestMessageTransmitter
+     */
+    private $transmitter;
+
+    public function testDynamicallyRegisterIfSupported(): void
+    {
+        $this->initListener(new ClientCapabilities([
+            'didChangeWatchedFiles' => ['dynamicRegistration' => true],
+        ]));
+        $this->dispatch(
+            new Initialized(),
+        );
+
+        self::assertCount(1, $this->transmitter);
+
+        $request = $this->transmitter->shiftRequest();
+        self::assertEquals('client/registerCapability', $request->method);
+        $registrations = $request->params['registrations'] ?? null;
+        self::assertIsArray($registrations);
+        self::assertCount(1, $registrations);
+
+        $registration = $registrations[0];
+        self::assertInstanceOf(Registration::class, $registration);
+        self::assertEquals('workspace/didChangeWatchedFiles', $registration->method);
+
+        $options = $registration->registerOptions;
+        self::assertInstanceOf(DidChangeWatchedFilesRegistrationOptions::class, $options);
+        self::assertCount(1, $options->watchers);
+
+        $watcher = $options->watchers[0];
+        self::assertInstanceOf(FileSystemWatcher::class, $watcher);
+        self::assertEquals('*.php', $watcher->globPattern);
+        self::assertNull($watcher->kind);
+    }
+
+    public function testDoesNotDynamicallyRegisterIfNotSupported(): void
+    {
+        $this->initListener(new ClientCapabilities());
+        $this->dispatch(
+            new Initialized(),
+        );
+
+        self::assertCount(0, $this->transmitter);
+    }
+
+    protected function initListener(ClientCapabilities $clientCapabilities): void
+    {
+        $client = TestRpcClient::create();
+        $api = new ClientApi($client);
+        $this->transmitter = $client->transmitter();
+        $this->listener = new DidChangeWatchedFilesListener($api, ['*.php'], $clientCapabilities);
+    }
+
+    private function dispatch(object $event): void
+    {
+        foreach ($this->listener->getListenersForEvent($event) as $listener) {
+            $listener($event);
+        };
+    }
+}


### PR DESCRIPTION
Proposal to fix https://github.com/phpactor/phpactor/issues/1304
Should also fix https://github.com/phpactor/phpactor/issues/1311

Before dynamically registering the new capability, first make sure the client accept dynamic registration for this capability.

TODO: update https://github.com/phpactor/language-server-extension/pull/25 if/when merged