### PR TITLE
Fixing the command line arguments

### DIFF
--- a/bin/serve.php
+++ b/bin/serve.php
@@ -47,14 +47,23 @@ use function Safe\fopen;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$options = [
-    'type' => 'tcp',
-    'address' => null,
-];
+if ($argc === 1) {
+    echo <<<DOC
+Usage: serve.php --address=127.0.0.1:9000 --type=tcp
 
-$options = array_merge($options, getopt('t::a::', ['type::', 'address::']));
-$type = $options['type'];
-$address = $options['address'];
+Parameters:
+-a --address
+    Address of the server. (needs to be set for a tcp server)
+-t --type
+    Type of server (optional, default is tcp)
+DOC;
+    exit(1);
+}
+
+$cliOptions = getopt('t::a::', ['type::', 'address::']);
+$type = $cliOptions['t'] ?? $cliOptions['type'] ?? 'tcp';
+$address = $cliOptions['a'] ?? $cliOptions['address'] ?? null;
+
 if ($type === 'tcp' && !is_string($address)) {
     throw new RuntimeException('Address should be a string');
 }

--- a/phpactor-lsp.log
+++ b/phpactor-lsp.log
@@ -1,0 +1,8 @@
+{"level":"info","message":"test language server starting","context":[]}
+
+{"level":"info","message":"i am a demonstration server and provide no functionality","context":[]}
+
+{"level":"info","message":"Listening on 127.0.0.1:9012","context":[]}
+
+{"level":"info","message":"Shutting down","context":[]}
+

--- a/phpactor-lsp.log
+++ b/phpactor-lsp.log
@@ -1,8 +1,0 @@
-{"level":"info","message":"test language server starting","context":[]}
-
-{"level":"info","message":"i am a demonstration server and provide no functionality","context":[]}
-
-{"level":"info","message":"Listening on 127.0.0.1:9012","context":[]}
-
-{"level":"info","message":"Shutting down","context":[]}
-


### PR DESCRIPTION
and adding documentation on how to invoke the serve.php

## Problem
First I couldn't figure out how to run the command. And it turns out that using the short options wasn't supported.

Secondly a usage section is always nice to have if running the program with no arguments (like in this case) is not possible.