### PR TITLE
Fix error response objects not conforming to JSON-RPC 2.0

### DIFF
--- a/lib/Core/Rpc/ResponseMessage.php
+++ b/lib/Core/Rpc/ResponseMessage.php
@@ -36,12 +36,13 @@ final class ResponseMessage extends Message implements JsonSerializable
     {
         $response = [
             'jsonrpc' => $this->jsonrpc,
-            'id' => $this->id,
-            'result' => $this->result,
+            'id' => $this->id
         ];
 
         if (null !== $this->error) {
             $response['error'] = $this->error;
+        } else {
+            $response['result'] = $this->result;
         }
 
         return $response;

--- a/lib/Core/Server/Transmitter/LspMessageSerializer.php
+++ b/lib/Core/Server/Transmitter/LspMessageSerializer.php
@@ -12,7 +12,7 @@ final class LspMessageSerializer implements MessageSerializer
     {
         $data = $this->normalize($message);
         if ($message instanceof ResponseMessage) {
-            $data = $this->ensureResultIsSet($data);
+            $data = $this->ensureOnlyResultOrErrorSet($data);
         }
         $decoded = json_encode($data);
 
@@ -49,9 +49,14 @@ final class LspMessageSerializer implements MessageSerializer
         });
     }
 
-    private function ensureResultIsSet(array $data): array
+    private function ensureOnlyResultOrErrorSet(array $data): array
     {
-        if (!array_key_exists('result', $data)) {
+        if (array_key_exists('error', $data) && array_key_exists('result', $data)) {
+            unset($data['result']);
+            return $data;
+        }
+
+        if (!array_key_exists('error', $data) && !array_key_exists('result', $data)) {
             $data['result'] = null;
         }
 

--- a/tests/Unit/Core/Server/Transmitter/LspMessageSerializerTest.php
+++ b/tests/Unit/Core/Server/Transmitter/LspMessageSerializerTest.php
@@ -36,7 +36,7 @@ class LspMessageSerializerTest extends TestCase
     {
         yield 'response message' => [
             new ResponseMessage(1, [], new ResponseError(1, 'foobar', [])),
-            '{"id":1,"result":[],"error":{"code":1,"message":"foobar","data":[]},"jsonrpc":"2.0"}',
+            '{"id":1,"error":{"code":1,"message":"foobar","data":[]},"jsonrpc":"2.0"}',
         ];
 
         yield 'response message with null result' => [


### PR DESCRIPTION
LspMessageSerializer and ResponseMessage::jsonSerialize are adding `result` property to a serialized response object data, which is not valid if there was an error invoking the method 

https://www.jsonrpc.org/specification#response_object
