### PR TITLE
Protocol 3.17

### DIFF
--- a/bin/serve.php
+++ b/bin/serve.php
@@ -148,7 +148,8 @@ $builder = LanguageServerBuilder::create(new ClosureDispatcherFactory(
         return new MiddlewareDispatcher(
             new ErrorHandlingMiddleware($logger),
             new InitializeMiddleware($handlers, $eventDispatcher, [
-                'version' => 1,
+                'name' => 'phpactor',
+                'version' => '1',
             ]),
             new CancellationMiddleware($runner),
             new ResponseHandlingMiddleware($responseWatcher),

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "amphp/socket": "^1.1",
         "dantleech/argument-resolver": "^1.1",
         "dantleech/invoke": "^2.0",
-        "phpactor/language-server-protocol": "dev-3.17-2",
+        "phpactor/language-server-protocol": "^3.17",
         "psr/event-dispatcher": "^1.0",
         "psr/log": "^1.0",
         "ramsey/uuid": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "amphp/socket": "^1.1",
         "dantleech/argument-resolver": "^1.1",
         "dantleech/invoke": "^2.0",
-        "phpactor/language-server-protocol": "~0.1",
+        "phpactor/language-server-protocol": "dev-3.17-2",
         "psr/event-dispatcher": "^1.0",
         "psr/log": "^1.0",
         "ramsey/uuid": "^4.0",

--- a/example/server/acme-ls/AcmeLsDispatcherFactory.php
+++ b/example/server/acme-ls/AcmeLsDispatcherFactory.php
@@ -81,7 +81,8 @@ class AcmeLsDispatcherFactory implements DispatcherFactory
         return new MiddlewareDispatcher(
             new ErrorHandlingMiddleware($this->logger),
             new InitializeMiddleware($handlers, $eventDispatcher, [
-                'version' => 1,
+                'name' => 'acme',
+                'version' => '1',
             ]),
             new ShutdownMiddleware($eventDispatcher),
             new ResponseHandlingMiddleware($responseWatcher),

--- a/lib/Core/CodeAction/CodeActionProvider.php
+++ b/lib/Core/CodeAction/CodeActionProvider.php
@@ -5,6 +5,7 @@ namespace Phpactor\LanguageServer\Core\CodeAction;
 use Amp\CancellationToken;
 use Amp\Promise;
 use Phpactor\LanguageServerProtocol\CodeAction;
+use Phpactor\LanguageServerProtocol\CodeActionKind;
 use Phpactor\LanguageServerProtocol\Range;
 use Phpactor\LanguageServerProtocol\TextDocumentItem;
 
@@ -21,7 +22,7 @@ interface CodeActionProvider
      *
      * @see Phpactor\LanguageServerProtocol\CodeAction
      *
-     * @return array<string>
+     * @return list<CodeActionKind::*>
      */
     public function kinds(): array;
 }

--- a/lib/Core/Server/Client/WorkspaceClient.php
+++ b/lib/Core/Server/Client/WorkspaceClient.php
@@ -4,7 +4,7 @@ namespace Phpactor\LanguageServer\Core\Server\Client;
 
 use Amp\Promise;
 use DTL\Invoke\Invoke;
-use Phpactor\LanguageServerProtocol\ApplyWorkspaceEditResponse;
+use Phpactor\LanguageServerProtocol\ApplyWorkspaceEditResult;
 use Phpactor\LanguageServerProtocol\WorkspaceEdit;
 use Phpactor\LanguageServer\Core\Server\RpcClient;
 
@@ -21,7 +21,7 @@ final class WorkspaceClient
     }
 
     /**
-     * @return Promise<ApplyWorkspaceEditResponse>
+     * @return Promise<ApplyWorkspaceEditResult>
      */
     public function applyEdit(WorkspaceEdit $edit, ?string $label = null): Promise
     {
@@ -34,7 +34,7 @@ final class WorkspaceClient
                 ]
             );
 
-            return Invoke::new(ApplyWorkspaceEditResponse::class, (array)$response->result);
+            return Invoke::new(ApplyWorkspaceEditResult::class, (array)$response->result);
         });
     }
 

--- a/lib/Event/TextDocumentSaved.php
+++ b/lib/Event/TextDocumentSaved.php
@@ -2,27 +2,25 @@
 
 namespace Phpactor\LanguageServer\Event;
 
+use Phpactor\LanguageServerProtocol\TextDocumentIdentifier;
 use Phpactor\LanguageServerProtocol\VersionedTextDocumentIdentifier;
 
 class TextDocumentSaved
 {
-    /**
-     * @var VersionedTextDocumentIdentifier
-     */
-    private $identifier;
+    private TextDocumentIdentifier $identifier;
 
     /**
      * @var string|null
      */
     private $text;
 
-    public function __construct(VersionedTextDocumentIdentifier $identifier, ?string $text = null)
+    public function __construct(TextDocumentIdentifier $identifier, ?string $text = null)
     {
         $this->identifier = $identifier;
         $this->text = $text;
     }
 
-    public function identifier(): VersionedTextDocumentIdentifier
+    public function identifier(): TextDocumentIdentifier
     {
         return $this->identifier;
     }

--- a/lib/Event/TextDocumentSaved.php
+++ b/lib/Event/TextDocumentSaved.php
@@ -3,7 +3,6 @@
 namespace Phpactor\LanguageServer\Event;
 
 use Phpactor\LanguageServerProtocol\TextDocumentIdentifier;
-use Phpactor\LanguageServerProtocol\VersionedTextDocumentIdentifier;
 
 class TextDocumentSaved
 {

--- a/lib/Example/CodeAction/SayHelloCodeActionProvider.php
+++ b/lib/Example/CodeAction/SayHelloCodeActionProvider.php
@@ -5,6 +5,7 @@ namespace Phpactor\LanguageServer\Example\CodeAction;
 use Amp\CancellationToken;
 use Amp\Promise;
 use Phpactor\LanguageServerProtocol\CodeAction;
+use Phpactor\LanguageServerProtocol\CodeActionKind;
 use Phpactor\LanguageServerProtocol\Command;
 use Phpactor\LanguageServerProtocol\Range;
 use Phpactor\LanguageServerProtocol\TextDocumentItem;
@@ -38,6 +39,6 @@ class SayHelloCodeActionProvider implements CodeActionProvider
      */
     public function kinds(): array
     {
-        return ['example'];
+        return [CodeActionKind::QUICK_FIX];
     }
 }

--- a/lib/Listener/DidChangeWatchedFilesListener.php
+++ b/lib/Listener/DidChangeWatchedFilesListener.php
@@ -50,7 +50,7 @@ class DidChangeWatchedFilesListener implements ListenerProviderInterface
 
     public function registerCapability(Initialized $initialized): void
     {
-        if (!($this->clientCapabilities->workspace['didChangeWatchedFiles']['dynamicRegistration'] ?? false)) {
+        if (!($this->clientCapabilities?->workspace?->didChangeWatchedFiles?->dynamicRegistration ?? false)) {
             return;
         }
 

--- a/lib/Middleware/InitializeMiddleware.php
+++ b/lib/Middleware/InitializeMiddleware.php
@@ -24,26 +24,14 @@ class InitializeMiddleware implements Middleware
     private const METHOD_INITIALIZE = 'initialize';
 
     /**
-     * @var Handlers
-     */
-    private $handlers;
-
-    /**
      * @var bool
      */
     private $initialized = false;
 
     /**
-     * @var EventDispatcherInterface
+     * @param array{name?:string,version?:string} $serverInfo
      */
-    private $dispatcher;
-
-    /**
-     * @var array
-     */
-    private $serverInfo;
-
-    public function __construct(Handlers $handlers, EventDispatcherInterface $dispatcher, array $serverInfo = [])
+    public function __construct(private Handlers $handlers, private EventDispatcherInterface $dispatcher, private array $serverInfo = [])
     {
         $this->handlers = $handlers;
         $this->dispatcher = $dispatcher;
@@ -88,7 +76,10 @@ class InitializeMiddleware implements Middleware
         return new Success(
             new ResponseMessage(
                 $request->id,
-                new InitializeResult($serverCapabilities, $this->serverInfo)
+                new InitializeResult($serverCapabilities, array_merge([
+                    'name' => 'unspecified',
+                    'version' => 'unspecified',
+                ], $this->serverInfo))
             )
         );
     }

--- a/lib/Test/ProtocolFactory.php
+++ b/lib/Test/ProtocolFactory.php
@@ -21,9 +21,9 @@ final class ProtocolFactory
         return new TextDocumentItem($uri, 'php', 1, $content);
     }
 
-    public static function versionedTextDocumentIdentifier(?string $uri = 'foobar', ?int $version = null): VersionedTextDocumentIdentifier
+    public static function versionedTextDocumentIdentifier(string $uri, int $version): VersionedTextDocumentIdentifier
     {
-        return new VersionedTextDocumentIdentifier($uri, $version);
+        return new VersionedTextDocumentIdentifier($version, $uri);
     }
 
     public static function textDocumentIdentifier(string $uri): TextDocumentIdentifier

--- a/lib/WorkDoneProgress/ClientCapabilityDependentProgressNotifier.php
+++ b/lib/WorkDoneProgress/ClientCapabilityDependentProgressNotifier.php
@@ -58,7 +58,7 @@ final class ClientCapabilityDependentProgressNotifier implements ProgressNotifie
 
     private function createNotifier(ClientApi $api, ClientCapabilities $capabilities): ProgressNotifier
     {
-        if ($capabilities->window['workDoneProgress'] ?? false) {
+        if ($capabilities->window->workDoneProgress ?? false) {
             return new WorkDoneProgressNotifier($api);
         }
 

--- a/tests/Unit/Core/Server/ClientApiTest.php
+++ b/tests/Unit/Core/Server/ClientApiTest.php
@@ -5,7 +5,7 @@ namespace Phpactor\LanguageServer\Tests\Unit\Core\Server;
 use Amp\PHPUnit\AsyncTestCase;
 use Closure;
 use Generator;
-use Phpactor\LanguageServerProtocol\ApplyWorkspaceEditResponse;
+use Phpactor\LanguageServerProtocol\ApplyWorkspaceEditResult;
 use Phpactor\LanguageServerProtocol\DidChangeWatchedFilesRegistrationOptions;
 use Phpactor\LanguageServerProtocol\FileSystemWatcher;
 use Phpactor\LanguageServerProtocol\MessageActionItem;
@@ -145,7 +145,7 @@ class ClientApiTest extends AsyncTestCase
                 self::assertEquals('workspace/applyEdit', $message->method);
 
                 $result = \Amp\Promise\wait($result);
-                self::assertInstanceOf(ApplyWorkspaceEditResponse::class, $result);
+                self::assertInstanceOf(ApplyWorkspaceEditResult::class, $result);
                 self::assertFalse($result->applied);
                 self::assertEquals('sorry', $result->failureReason);
             }

--- a/tests/Unit/Handler/TextDocument/TextDocumentHandlerTest.php
+++ b/tests/Unit/Handler/TextDocument/TextDocumentHandlerTest.php
@@ -57,7 +57,7 @@ class TextDocumentHandlerTest extends HandlerTestCase
     public function testUpdatesDocument(): void
     {
         $textDocument = ProtocolFactory::textDocumentItem('foobar', 'foo');
-        $identifier = ProtocolFactory::versionedTextDocumentIdentifier('foobar');
+        $identifier = ProtocolFactory::versionedTextDocumentIdentifier('foobar', 1);
 
         $this->dispatch('textDocument/didChange', [
             'textDocument' => $identifier,
@@ -100,7 +100,7 @@ class TextDocumentHandlerTest extends HandlerTestCase
 
     public function testSavesDocument(): void
     {
-        $identifier = ProtocolFactory::versionedTextDocumentIdentifier('foobar');
+        $identifier = ProtocolFactory::versionedTextDocumentIdentifier('foobar', 1);
         $this->dispatch('textDocument/didSave', [
             'textDocument' => $identifier,
             'text' => 'hello',

--- a/tests/Unit/Listener/DidChangeWatchedFilesListenerTest.php
+++ b/tests/Unit/Listener/DidChangeWatchedFilesListenerTest.php
@@ -3,9 +3,11 @@
 namespace Phpactor\LanguageServer\Tests\Unit\Listener;
 
 use Phpactor\LanguageServerProtocol\ClientCapabilities;
+use Phpactor\LanguageServerProtocol\DidChangeWatchedFilesClientCapabilities;
 use Phpactor\LanguageServerProtocol\DidChangeWatchedFilesRegistrationOptions;
 use Phpactor\LanguageServerProtocol\FileSystemWatcher;
 use Phpactor\LanguageServerProtocol\Registration;
+use Phpactor\LanguageServerProtocol\WorkspaceClientCapabilities;
 use Phpactor\LanguageServer\Core\Server\ClientApi;
 use Phpactor\LanguageServer\Core\Server\RpcClient\TestRpcClient;
 use Phpactor\LanguageServer\Core\Server\Transmitter\TestMessageTransmitter;
@@ -27,9 +29,11 @@ class DidChangeWatchedFilesListenerTest extends TestCase
 
     public function testDynamicallyRegisterIfSupported(): void
     {
-        $this->initListener(new ClientCapabilities([
-            'didChangeWatchedFiles' => ['dynamicRegistration' => true],
-        ]));
+        $this->initListener(new ClientCapabilities(
+            workspace: new WorkspaceClientCapabilities(
+                didChangeWatchedFiles: new DidChangeWatchedFilesClientCapabilities(dynamicRegistration: true),
+            )
+        ));
         $this->dispatch(
             new Initialized(),
         );

--- a/tests/Unit/Listener/WorkspaceListenerTest.php
+++ b/tests/Unit/Listener/WorkspaceListenerTest.php
@@ -3,7 +3,6 @@
 namespace Phpactor\LanguageServer\Tests\Unit\Listener;
 
 use Phpactor\LanguageServerProtocol\TextDocumentItem;
-use Phpactor\LanguageServerProtocol\VersionedTextDocumentIdentifier;
 use Phpactor\LanguageServer\Core\Workspace\Workspace;
 use Phpactor\LanguageServer\Listener\WorkspaceListener;
 use Phpactor\LanguageServer\Event\TextDocumentClosed;
@@ -54,7 +53,7 @@ class WorkspaceListenerTest extends TestCase
 
     public function testUpdated(): void
     {
-        $identifier = new VersionedTextDocumentIdentifier('file://test', 1);
+        $identifier = ProtocolFactory::versionedTextDocumentIdentifier('file://test', 1);
         $this->workspace->update(
             $identifier,
             'new text'

--- a/tests/Unit/Middleware/InitializeMiddlewareTest.php
+++ b/tests/Unit/Middleware/InitializeMiddlewareTest.php
@@ -83,7 +83,8 @@ class InitializeMiddlewareTest extends AsyncTestCase
     public function testReturnsInitializedResponse(): Generator
     {
         $middleware = $this->createMiddleware([], [
-            'server_info' => 'please',
+            'name' => 'test',
+            'version' => '12a'
         ]);
 
         $response = yield $middleware->process(
@@ -95,7 +96,8 @@ class InitializeMiddlewareTest extends AsyncTestCase
         self::assertInstanceOf(ResponseMessage::class, $response);
         self::assertInstanceOf(InitializeResult::class, $response->result);
         self::assertEquals([
-            'server_info' => 'please',
+            'name' => 'test',
+            'version' => '12a'
         ], $response->result->serverInfo);
     }
 


### PR DESCRIPTION
Update the Language Server Protocol to 3.17

Things to note when updating Phpactor:

- The protocol generation does not preserve order of constructor arguments - and many of them _have changed_. where necessary it would make sense to use named parameters to avoid more work in the future.
- The VersionedTextDocumentIdentifier has changed so that the version is not nullable, in such cases I would hope the `TextDocumentIdentifier` will be passed where NULL was previously used. This may cause some issues.
- Some classes were renamed in VSCode, e.g. `ApplyWorkspaceEditResponse` is now `ApplyWorkspaceEditResult`. It doesn't affect the protocol (the fields are still the same) but there are perhaps more renames that will affect Phpactor.