### PR TITLE
Allow any string in CodeActionProvider::kinds method

### DIFF
--- a/lib/Core/CodeAction/CodeActionProvider.php
+++ b/lib/Core/CodeAction/CodeActionProvider.php
@@ -5,7 +5,6 @@ namespace Phpactor\LanguageServer\Core\CodeAction;
 use Amp\CancellationToken;
 use Amp\Promise;
 use Phpactor\LanguageServerProtocol\CodeAction;
-use Phpactor\LanguageServerProtocol\CodeActionKind;
 use Phpactor\LanguageServerProtocol\Range;
 use Phpactor\LanguageServerProtocol\TextDocumentItem;
 
@@ -22,7 +21,7 @@ interface CodeActionProvider
      *
      * @see Phpactor\LanguageServerProtocol\CodeAction
      *
-     * @return list<CodeActionKind::*>
+     * @return string[]
      */
     public function kinds(): array;
 }


### PR DESCRIPTION
As per specification this list is open - https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionKind

Resolves #54 