### PR TITLE
Better diagnostic engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.0
+---
+
+- Refactored diagnostics engine to execute diagnostic providers in parallel
+
 5.0
 ---
 

--- a/bin/serve.php
+++ b/bin/serve.php
@@ -106,10 +106,10 @@ $builder = LanguageServerBuilder::create(new ClosureDispatcherFactory(
         $clientApi = new ClientApi(new JsonRpcClient($transmitter, $responseWatcher));
 
         $diagnosticsService = new DiagnosticsService(
-            new DiagnosticsEngine($clientApi, new AggregateDiagnosticsProvider(
+            new DiagnosticsEngine($clientApi, [new AggregateDiagnosticsProvider(
                 $logger,
                 new SayHelloDiagnosticsProvider()
-            ))
+            )])
         );
 
         $serviceProviders = new ServiceProviders($diagnosticsService);

--- a/lib/Core/Diagnostics/DiagnosticsEngine.php
+++ b/lib/Core/Diagnostics/DiagnosticsEngine.php
@@ -86,7 +86,7 @@ class DiagnosticsEngine
                     $this->next = null;
                 }
 
-                foreach ($this->providers as $provider) {
+                foreach ($this->providers as $i => $provider) {
                     asyncCall(function () use ($provider, $token, $textDocument) {
                         $this->diagnostics = array_merge(
                             $this->diagnostics,

--- a/lib/Core/Diagnostics/DiagnosticsEngine.php
+++ b/lib/Core/Diagnostics/DiagnosticsEngine.php
@@ -15,32 +15,17 @@ class DiagnosticsEngine
     /**
      * @var Deferred<TextDocumentItem>
      */
-    private $deferred;
+    private Deferred $deferred;
 
-    /**
-     * @var bool
-     */
-    private $running = false;
+    private bool $running = false;
 
-    /**
-     * @var ?TextDocumentItem
-     */
-    private $next;
+    private ?TextDocumentItem $next = null;
 
-    /**
-     * @var DiagnosticsProvider
-     */
-    private $provider;
+    private DiagnosticsProvider $provider;
 
-    /**
-     * @var ClientApi
-     */
-    private $clientApi;
+    private ClientApi $clientApi;
 
-    /**
-     * @var int
-     */
-    private $sleepTime;
+    private int $sleepTime;
 
     public function __construct(ClientApi $clientApi, DiagnosticsProvider $provider, int $sleepTime = 1000)
     {

--- a/lib/Core/Diagnostics/DiagnosticsEngine.php
+++ b/lib/Core/Diagnostics/DiagnosticsEngine.php
@@ -5,7 +5,6 @@ namespace Phpactor\LanguageServer\Core\Diagnostics;
 use Amp\CancelledException;
 use Amp\Success;
 use Phpactor\LanguageServerProtocol\Diagnostic;
-use Phpactor\LanguageServerProtocol\TextDocument;
 use Phpactor\LanguageServer\Core\Server\ClientApi;
 use Amp\Promise;
 use Amp\CancellationToken;
@@ -45,14 +44,9 @@ class DiagnosticsEngine
     private array $versions = [];
 
     /**
-     * @var array<string,Deferred>
+     * @var array<string,Deferred<bool>>
      */
     private array $locks = [];
-
-    /**
-     * @var array<string,int>
-     */
-    private array $concurrencies = [];
 
     /**
      * @param DiagnosticsProvider[] $providers
@@ -174,11 +168,14 @@ class DiagnosticsEngine
         $this->deferred->resolve($textDocument);
     }
 
-    private function isDocumentCurrent(?TextDocumentItem $textDocument): bool
+    private function isDocumentCurrent(TextDocumentItem $textDocument): bool
     {
         return $textDocument->version === ($this->versions[$textDocument->uri] ?? -1);
     }
-
+    /**
+     * @param string|int $providerId
+     * @return Promise<bool>
+     */
     private function await($providerId): Promise
     {
         if (!array_key_exists($providerId, $this->locks)) {

--- a/lib/LanguageServerTesterBuilder.php
+++ b/lib/LanguageServerTesterBuilder.php
@@ -326,7 +326,7 @@ final class LanguageServerTesterBuilder
                     $service = new DiagnosticsService(
                         new DiagnosticsEngine(
                             $this->clientApi,
-                            new AggregateDiagnosticsProvider($logger, ...$this->diagnosticsProvider),
+                            [new AggregateDiagnosticsProvider($logger, ...$this->diagnosticsProvider)],
                             0
                         ),
                     );

--- a/tests/Unit/Core/Diagnostics/DiagnosticsEngineTest.php
+++ b/tests/Unit/Core/Diagnostics/DiagnosticsEngineTest.php
@@ -107,7 +107,7 @@ class DiagnosticsEngineTest extends AsyncTestCase
 
         $token->cancel();
 
-        self::assertEquals(4, $tester->transmitter()->count());
+        self::assertEquals(6, $tester->transmitter()->count());
     }
 
     public function testAggregatesResultsFromMultipleProviders(): Generator

--- a/tests/Unit/Core/Diagnostics/DiagnosticsEngineTest.php
+++ b/tests/Unit/Core/Diagnostics/DiagnosticsEngineTest.php
@@ -148,20 +148,18 @@ class DiagnosticsEngineTest extends AsyncTestCase
 
     private function createEngine(LanguageServerTesterBuilder $tester, int $delay = 0, int $sleepTime = 0, string &$lastDocument = null): DiagnosticsEngine
     {
-        $engine = new DiagnosticsEngine($tester->clientApi(), new ClosureDiagnosticsProvider(function (TextDocumentItem $item) use ($delay, &$lastDocument) {
-            return call(function () use ($delay, $item, &$lastDocument) {
-                if ($delay) {
-                    yield delay($delay);
-                }
-                $lastDocument = $item->text;
-                return [
-                    ProtocolFactory::diagnostic(
-                        ProtocolFactory::range(0, 0, 0, 0),
-                        'Foobar is broken'
-                    )
-                ];
-            });
-        }), $sleepTime);
-        return $engine;
+        return new DiagnosticsEngine($tester->clientApi(), [
+            new ClosureDiagnosticsProvider(function (TextDocumentItem $item) use ($delay, &$lastDocument) {
+                return call(function () use ($delay, $item, &$lastDocument) {
+                    if ($delay) {
+                        yield delay($delay);
+                    }
+                    $lastDocument = $item->text;
+                    return [
+                        ProtocolFactory::diagnostic(ProtocolFactory::range(0, 0, 0, 0), 'Foobar is broken')
+                    ];
+                });
+            })
+        ], $sleepTime);
     }
 }

--- a/tests/Unit/Core/Diagnostics/DiagnosticsEngineTest.php
+++ b/tests/Unit/Core/Diagnostics/DiagnosticsEngineTest.php
@@ -70,7 +70,7 @@ class DiagnosticsEngineTest extends AsyncTestCase
     public function testDeduplicatesSuccessiveChangesToSameFile(): Generator
     {
         $tester = LanguageServerTesterBuilder::create();
-        $engine = $this->createEngine($tester, 5, 0);
+        $engine = $this->createEngine($tester, 10, 0);
 
         $token = new CancellationTokenSource();
         $promise = $engine->run($token->getToken());
@@ -136,7 +136,7 @@ class DiagnosticsEngineTest extends AsyncTestCase
         $engine->enqueue(ProtocolFactory::textDocumentItem('file:///foobar', '3'));
         yield new Delayed(1);
         $engine->enqueue(ProtocolFactory::textDocumentItem('file:///foobar', '4'));
-        yield new Delayed(0);
+        yield new Delayed(1);
         $engine->enqueue(ProtocolFactory::textDocumentItem('file:///foobar', '5'));
 
         yield new Delayed(100);

--- a/tests/Unit/Core/Diagnostics/DiagnosticsEngineTest.php
+++ b/tests/Unit/Core/Diagnostics/DiagnosticsEngineTest.php
@@ -78,11 +78,13 @@ class DiagnosticsEngineTest extends AsyncTestCase
 
         $engine->enqueue(ProtocolFactory::textDocumentItem('file:///foobar', 'foobar'));
         $engine->enqueue(ProtocolFactory::textDocumentItem('file:///foobar', 'foobar'));
+        $engine->enqueue(ProtocolFactory::textDocumentItem('file:///foobar', 'foobar'));
 
-        yield new Delayed(10);
+        yield new Delayed(1);
 
         $token->cancel();
 
+        // clear three times
         self::assertEquals(3, $tester->transmitter()->count());
     }
 

--- a/tests/Unit/Diagnostics/CodeActionDiagnosticsProviderTest.php
+++ b/tests/Unit/Diagnostics/CodeActionDiagnosticsProviderTest.php
@@ -32,12 +32,12 @@ class CodeActionDiagnosticsProviderTest extends TestCase
 
         wait(new Delayed(10));
 
-        self::assertEquals(1, $tester->transmitter()->count());
+        self::assertEquals(2, $tester->transmitter()->count());
 
         $tester->textDocument()->update('file:///foobar', 'bar');
         wait(new Delayed(10));
 
-        self::assertEquals(3, $tester->transmitter()->count());
+        self::assertEquals(5, $tester->transmitter()->count());
         self::assertEquals('textDocument/publishDiagnostics', $tester->transmitter()->shiftNotification()->method);
     }
 }

--- a/tests/Unit/Service/DiagnosticsServiceTest.php
+++ b/tests/Unit/Service/DiagnosticsServiceTest.php
@@ -24,16 +24,18 @@ class DiagnosticsServiceTest extends TestCase
         $service = new DiagnosticsService(
             new DiagnosticsEngine(
                 $tester->clientApi(),
-                new ClosureDiagnosticsProvider(function () {
-                    return call(function () {
-                        return [
-                            ProtocolFactory::diagnostic(
-                                ProtocolFactory::range(0, 0, 0, 0),
-                                'Foobar is bust'
-                            )
-                        ];
-                    });
-                }),
+                [
+                    new ClosureDiagnosticsProvider(function () {
+                        return call(function () {
+                            return [
+                                ProtocolFactory::diagnostic(
+                                    ProtocolFactory::range(0, 0, 0, 0),
+                                    'Foobar is bust'
+                                )
+                            ];
+                        });
+                    }),
+                ],
                 0
             ),
             true,
@@ -54,7 +56,7 @@ class DiagnosticsServiceTest extends TestCase
         assert($notification instanceof NotificationMessage);
         self::assertEquals('textDocument/publishDiagnostics', $notification->method);
 
-        $tester->textDocument()->save('file:///foobar', 'foobar');
+        $tester->textDocument()->save('file:///foobar');
         wait(new Delayed(100));
         $notification = $tester->transmitter()->shift();
         assert($notification instanceof NotificationMessage);


### PR DESCRIPTION
- Execute diagnostic providers in parallel
- Lock to ensure only one of each is executed at any given time
- Always clear diagonstics when document changes