### PR TITLE
Make the use of POSIX signals optional

### DIFF
--- a/lib/Core/Server/LanguageServer.php
+++ b/lib/Core/Server/LanguageServer.php
@@ -93,10 +93,13 @@ final class LanguageServer
      */
     public function run(): void
     {
-        Loop::onSignal(SIGINT, function (string $watcherId) {
-            Loop::cancel($watcherId);
-            yield $this->shutdown();
-        });
+        // Signals are not supported on Windows
+        if(defined('SIGINT')) {
+            Loop::onSignal(SIGINT, function (string $watcherId) {
+                Loop::cancel($watcherId);
+                yield $this->shutdown();
+            });
+        }
 
         Loop::setErrorHandler(function (Throwable $error): void {
             if ($error instanceof ShutdownServer) {


### PR DESCRIPTION
Signals are not supported on Windows, and gracefully shutting down everything doesn't seem necessary if we're about to exit anyway.