### PR TITLE
Add support for psr/log 2.0 and 3.0

### DIFF
--- a/bin/serve.php
+++ b/bin/serve.php
@@ -82,7 +82,7 @@ $logger = new class extends AbstractLogger {
         $this->log = fopen('phpactor-lsp.log', 'w');
     }
 
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         $message = json_encode(
             [

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,13 @@
         "dantleech/invoke": "^2.0",
         "phpactor/language-server-protocol": "^3.17",
         "psr/event-dispatcher": "^1.0",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "ramsey/uuid": "^4.0",
         "thecodingmachine/safe": "^1.1"
     },
     "require-dev": {
         "amphp/phpunit-util": "^1.3",
+        "colinodell/psr-testlogger": "^1.0",
         "ergebnis/composer-normalize": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.0",
         "jangregor/phpstan-prophecy": "^1.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,11 @@ parameters:
         - lib
         - example
         - bin
+    ignoreErrors:
+        -
+            message: '#has parameter \$(context|message) with no (value )?type specified#'
+            path: 'bin/serve.php'
+            reportUnmatched: false
 
 includes:
     - phpstan-baseline.neon

--- a/tests/Unit/Core/Service/ServiceManagerTest.php
+++ b/tests/Unit/Core/Service/ServiceManagerTest.php
@@ -8,6 +8,7 @@ use Amp\Delayed;
 use Amp\PHPUnit\AsyncTestCase;
 use Amp\Promise;
 use Amp\Success;
+use ColinODell\PsrTestLogger\TestLogger;
 use Exception;
 use Generator;
 use Phpactor\LanguageServer\Core\Dispatcher\ArgumentResolver;
@@ -15,7 +16,6 @@ use Phpactor\LanguageServer\Core\Service\ServiceProvider;
 use Phpactor\LanguageServer\Core\Service\ServiceManager;
 use Phpactor\LanguageServer\Core\Service\ServiceProviders;
 use Prophecy\PhpUnit\ProphecyTrait;
-use Psr\Log\Test\TestLogger;
 use RuntimeException;
 
 class ServiceManagerTest extends AsyncTestCase

--- a/tests/Unit/Middleware/ErrorHandlingMiddlewareTest.php
+++ b/tests/Unit/Middleware/ErrorHandlingMiddlewareTest.php
@@ -4,6 +4,7 @@ namespace Phpactor\LanguageServer\Tests\Unit\Middleware;
 
 use Amp\PHPUnit\AsyncTestCase;
 use Amp\Success;
+use ColinODell\PsrTestLogger\TestLogger;
 use Generator;
 use Phpactor\LanguageServer\Core\Handler\HandlerNotFound;
 use Phpactor\LanguageServer\Core\Middleware\RequestHandler;
@@ -15,7 +16,6 @@ use Phpactor\LanguageServer\Core\Rpc\ResponseMessage;
 use Phpactor\LanguageServer\Core\Server\Exception\ExitSession;
 use Phpactor\LanguageServer\Middleware\ClosureMiddleware;
 use Phpactor\LanguageServer\Middleware\ErrorHandlingMiddleware;
-use Psr\Log\Test\TestLogger;
 use RuntimeException;
 
 class ErrorHandlingMiddlewareTest extends AsyncTestCase


### PR DESCRIPTION
Fixes #60 
There are some caveats:
- as Psr\Log\Test\TestLogger was removed with psr/log:3.0 we need an alternative TestLogger for unit testing. [colinodell/psr-testlogger](https://github.com/colinodell/psr-testlogger) provides this, which works for all psr/log versions.
- we need to ignore phpstan errors in bin/serve.php as the inline class inheriting AbstractLogger needs more type hints depending on the psr/log version

Apart from that everything should work. phpunit and phpstan ran without errors.