### PR TITLE
Refactor: clean types

### DIFF
--- a/bin/serve.php
+++ b/bin/serve.php
@@ -48,14 +48,14 @@ require __DIR__ . '/../vendor/autoload.php';
 
 if (($argc ?? 0) === 1) {
     echo <<<DOC
-Usage: serve.php --address=127.0.0.1:9000 --type=tcp
+        Usage: serve.php --address=127.0.0.1:9000 --type=tcp
 
-Parameters:
--a --address
-    Address of the server. (needs to be set for a tcp server)
--t --type
-    Type of server (optional, default is tcp)
-DOC;
+        Parameters:
+        -a --address
+            Address of the server. (needs to be set for a tcp server)
+        -t --type
+            Type of server (optional, default is tcp)
+        DOC;
     exit(1);
 }
 
@@ -83,7 +83,7 @@ $logger = new class extends AbstractLogger {
         $this->log = fopen('phpactor-lsp.log', 'w');
     }
 
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         $message = json_encode(
             [

--- a/example/server/acme-ls/AcmeLsDispatcherFactory.php
+++ b/example/server/acme-ls/AcmeLsDispatcherFactory.php
@@ -15,7 +15,6 @@ use Phpactor\LanguageServerProtocol\InitializeParams;
 use Phpactor\LanguageServer\Core\Dispatcher\Dispatcher;
 use Phpactor\LanguageServer\Core\Handler\HandlerMethodRunner;
 use Phpactor\LanguageServer\Core\Dispatcher\DispatcherFactory;
-use Phpactor\LanguageServer\Handler\System\ExitHandler;
 use Phpactor\LanguageServer\Handler\Workspace\CommandHandler;
 use Phpactor\LanguageServer\Middleware\ResponseHandlingMiddleware;
 use Phpactor\LanguageServer\Core\Command\CommandDispatcher;
@@ -37,14 +36,8 @@ use Psr\Log\LoggerInterface;
 
 class AcmeLsDispatcherFactory implements DispatcherFactory
 {
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    public function __construct(LoggerInterface $logger)
+    public function __construct(private LoggerInterface $logger)
     {
-        $this->logger = $logger;
     }
 
     public function create(MessageTransmitter $transmitter, InitializeParams $initializeParams): Dispatcher

--- a/lib/Adapter/Psr/AggregateEventDispatcher.php
+++ b/lib/Adapter/Psr/AggregateEventDispatcher.php
@@ -10,7 +10,7 @@ class AggregateEventDispatcher implements EventDispatcherInterface
     /**
      * @var array<ListenerProviderInterface>
      */
-    private $listnerProviders;
+    private array $listnerProviders;
 
     public function __construct(ListenerProviderInterface ...$listnerProviders)
     {

--- a/lib/Core/CodeAction/AggregateCodeActionProvider.php
+++ b/lib/Core/CodeAction/AggregateCodeActionProvider.php
@@ -48,7 +48,7 @@ class AggregateCodeActionProvider implements CodeActionProvider
         return array_values(
             array_reduce(
                 $this->providers,
-                function (array $kinds, CodeActionProvider $provider) {
+                function (array $kinds, CodeActionProvider $provider): array {
                     return array_merge(
                         $kinds,
                         (array)array_combine($provider->kinds(), $provider->kinds())

--- a/lib/Core/Command/CommandDispatcher.php
+++ b/lib/Core/Command/CommandDispatcher.php
@@ -11,14 +11,9 @@ use RuntimeException;
 class CommandDispatcher
 {
     /**
-     * @var array
-     */
-    private $commandMap = [];
-
-    /**
      * @param array<string,Command> $commandMap Map of command names to invokable objects
      */
-    public function __construct(array $commandMap)
+    public function __construct(private array $commandMap = [])
     {
         foreach ($commandMap as $id => $command) {
             $this->addCommand($id, $command);

--- a/lib/Core/Diagnostics/AggregateDiagnosticsProvider.php
+++ b/lib/Core/Diagnostics/AggregateDiagnosticsProvider.php
@@ -14,7 +14,7 @@ class AggregateDiagnosticsProvider implements DiagnosticsProvider
     /**
      * @var array<DiagnosticsProvider>
      */
-    private $providers;
+    private array $providers;
 
     public function __construct(private LoggerInterface $logger, DiagnosticsProvider ...$providers)
     {
@@ -65,7 +65,7 @@ class AggregateDiagnosticsProvider implements DiagnosticsProvider
     public function names(): array
     {
         return array_map(
-            fn (DiagnosticsProvider $provider) => $provider->name(),
+            fn (DiagnosticsProvider $provider): string => $provider->name(),
             $this->providers
         );
     }

--- a/lib/Core/Diagnostics/DiagnosticsEngine.php
+++ b/lib/Core/Diagnostics/DiagnosticsEngine.php
@@ -189,10 +189,9 @@ class DiagnosticsEngine
     }
 
     /**
-     * @param string|int $providerId
      * @return Promise<bool>
      */
-    private function awaitProviderLock($providerId): Promise
+    private function awaitProviderLock(int|string $providerId): Promise
     {
         if (!array_key_exists($providerId, $this->locks)) {
             return new Success(true);

--- a/lib/Core/Dispatcher/ArgumentResolver/ChainArgumentResolver.php
+++ b/lib/Core/Dispatcher/ArgumentResolver/ChainArgumentResolver.php
@@ -11,7 +11,7 @@ final class ChainArgumentResolver implements ArgumentResolver
     /**
      * @var array<ArgumentResolver>
      */
-    private $resolvers;
+    private array $resolvers;
 
     public function __construct(ArgumentResolver ...$resolvers)
     {

--- a/lib/Core/Dispatcher/Dispatcher/MiddlewareDispatcher.php
+++ b/lib/Core/Dispatcher/Dispatcher/MiddlewareDispatcher.php
@@ -11,9 +11,9 @@ use Phpactor\LanguageServer\Core\Rpc\Message;
 final class MiddlewareDispatcher implements Dispatcher
 {
     /**
-     * @var array
+     * @var Middleware[]
      */
-    private $middleware;
+    private array $middleware;
 
     public function __construct(Middleware ...$middleware)
     {

--- a/lib/Core/Handler/ClosureHandler.php
+++ b/lib/Core/Handler/ClosureHandler.php
@@ -20,10 +20,7 @@ final class ClosureHandler implements Handler
         ];
     }
 
-    /**
-     * @return mixed
-     */
-    public function handle()
+    public function handle(): mixed
     {
         $args = func_get_args();
         return $this->closure->__invoke(...$args);

--- a/lib/Core/Handler/HandlerMethodRunner.php
+++ b/lib/Core/Handler/HandlerMethodRunner.php
@@ -20,7 +20,7 @@ final class HandlerMethodRunner implements MethodRunner
     /**
      * @var array<string|int, CancellationTokenSource>
      */
-    private $cancellations = [];
+    private array $cancellations = [];
 
     public function __construct(
         private Handlers $handlers,

--- a/lib/Core/Handler/Handlers.php
+++ b/lib/Core/Handler/Handlers.php
@@ -12,9 +12,9 @@ use IteratorAggregate;
 final class Handlers implements Countable, IteratorAggregate
 {
     /**
-     * @var array
+     * @var array<string, Handler>
      */
-    private $methods = [];
+    private array $methods = [];
 
     public function __construct(Handler ...$handlers)
     {

--- a/lib/Core/Server/LanguageServer.php
+++ b/lib/Core/Server/LanguageServer.php
@@ -33,7 +33,7 @@ final class LanguageServer
     /**
      * @var Connection[]
      */
-    private $connections = [];
+    private array $connections = [];
 
     public function __construct(
         private DispatcherFactory $dispatcherFactory,

--- a/lib/Core/Server/Parser/LspMessageReader.php
+++ b/lib/Core/Server/Parser/LspMessageReader.php
@@ -16,23 +16,19 @@ final class LspMessageReader implements RequestReader
     const EVENT_REQUEST_READY = 'request.ready';
     const HEADER_CONTENT_LENGTH = 'Content-Length';
 
-    /**
-     * @var string
-     */
-    private $buffer = '';
+    private string $buffer = '';
 
-    /**
-     * @var string
-     */
-    private $overflow = '';
+    private string $overflow = '';
 
     /**
      * @var null|array<string>
      */
-    private $headers = null;
+    private ?array $headers = null;
 
-    public function __construct(private InputStream $stream, private LoggerInterface $logger = new NullLogger())
-    {
+    public function __construct(
+        private InputStream $stream,
+        private LoggerInterface $logger = new NullLogger(),
+    ) {
     }
 
     public function wait(): Promise

--- a/lib/Core/Server/ResponseWatcher.php
+++ b/lib/Core/Server/ResponseWatcher.php
@@ -10,8 +10,7 @@ interface ResponseWatcher
     public function handle(ResponseMessage $response): void;
 
     /**
-     * @param int|string $requestId
      * @return Promise<ResponseMessage>
      */
-    public function waitForResponse($requestId): Promise;
+    public function waitForResponse(int|string $requestId): Promise;
 }

--- a/lib/Core/Server/ResponseWatcher/DeferredResponseWatcher.php
+++ b/lib/Core/Server/ResponseWatcher/DeferredResponseWatcher.php
@@ -13,7 +13,7 @@ final class DeferredResponseWatcher implements ResponseWatcher
     /**
      * @var array<string|int, Deferred<ResponseMessage>>
      */
-    private $watchers = [];
+    private array $watchers = [];
 
     public function handle(ResponseMessage $response): void
     {
@@ -29,11 +29,9 @@ final class DeferredResponseWatcher implements ResponseWatcher
     }
 
     /**
-     * @param string|int $requestId
-     *
      * @return Promise<ResponseMessage>
      */
-    public function waitForResponse($requestId): Promise
+    public function waitForResponse(int|string $requestId): Promise
     {
         $deferred = new Deferred();
         $this->watchers[$requestId] = $deferred;

--- a/lib/Core/Server/ResponseWatcher/TestResponseWatcher.php
+++ b/lib/Core/Server/ResponseWatcher/TestResponseWatcher.php
@@ -12,7 +12,7 @@ final class TestResponseWatcher implements ResponseWatcher
     /**
      * @var array
      */
-    private $requestIds = [];
+    private array $requestIds = [];
 
     public function __construct(private ResponseWatcher $innerWatcher = new DeferredResponseWatcher())
     {
@@ -40,7 +40,7 @@ final class TestResponseWatcher implements ResponseWatcher
     /**
      * {@inheritDoc}
      */
-    public function waitForResponse($requestId): Promise
+    public function waitForResponse(int|string $requestId): Promise
     {
         $this->requestIds[] = $requestId;
         return $this->innerWatcher->waitForResponse($requestId);

--- a/lib/Core/Server/RpcClient/TestRpcClient.php
+++ b/lib/Core/Server/RpcClient/TestRpcClient.php
@@ -9,10 +9,7 @@ use Phpactor\LanguageServer\Core\Server\Transmitter\TestMessageTransmitter;
 
 final class TestRpcClient implements RpcClient
 {
-    /**
-     * @var JsonRpcClient
-     */
-    private $client;
+    private JsonRpcClient $client;
 
     public function __construct(private TestMessageTransmitter $transmitter, private TestResponseWatcher $responseWatcher)
     {

--- a/lib/Core/Server/ServerStats.php
+++ b/lib/Core/Server/ServerStats.php
@@ -10,26 +10,11 @@ use DateTimeImmutable;
  */
 final class ServerStats implements ServerStatsReader
 {
-    /**
-     * @var DateTimeImmutable
-     */
-    private $created;
-
-    /**
-     * @var int
-     */
-    private $connectionCount;
-
-    /**
-     * @var int
-     */
-    private $requestCount;
-
-    public function __construct()
-    {
-        $this->created = new DateTimeImmutable();
-        $this->connectionCount = 0;
-        $this->requestCount = 0;
+    public function __construct(
+        private DateTimeImmutable $created = new DateTimeImmutable(),
+        private int $connectionCount = 0,
+        private int $requestCount = 0,
+    ) {
     }
 
     public function incConnectionCount(): void

--- a/lib/Core/Server/StreamProvider/ResourceStreamProvider.php
+++ b/lib/Core/Server/StreamProvider/ResourceStreamProvider.php
@@ -9,10 +9,7 @@ use Psr\Log\LoggerInterface;
 
 final class ResourceStreamProvider implements StreamProvider
 {
-    /**
-     * @var bool
-     */
-    private $provided = false;
+    private bool $provided = false;
 
     public function __construct(private ResourceDuplexStream $duplexStream, private LoggerInterface $logger)
     {

--- a/lib/Core/Server/Transmitter/LspMessageSerializer.php
+++ b/lib/Core/Server/Transmitter/LspMessageSerializer.php
@@ -45,7 +45,7 @@ final class LspMessageSerializer implements MessageSerializer
             return $message;
         }
 
-        return array_filter(array_map([$this, 'normalize'], $message), function ($value) {
+        return array_filter(array_map([$this, 'normalize'], $message), function ($value): bool {
             return $value !== null;
         });
     }

--- a/lib/Core/Server/Transmitter/TestMessageTransmitter.php
+++ b/lib/Core/Server/Transmitter/TestMessageTransmitter.php
@@ -13,7 +13,7 @@ final class TestMessageTransmitter implements MessageTransmitter, TestMessageTra
     /**
      * @var Message[]
      */
-    private $buffer = [];
+    private array $buffer = [];
 
     public function __construct(Message ...$buffer)
     {
@@ -27,7 +27,7 @@ final class TestMessageTransmitter implements MessageTransmitter, TestMessageTra
 
     public function filterByMethod(string $method): self
     {
-        return new self(...array_filter($this->buffer, function (Message $message) use ($method) {
+        return new self(...array_filter($this->buffer, function (Message $message) use ($method): bool {
             if (
                 !$message instanceof RequestMessage &&
                 !$message instanceof NotificationMessage

--- a/lib/Core/Service/ServiceManager.php
+++ b/lib/Core/Service/ServiceManager.php
@@ -13,9 +13,9 @@ use function Amp\asyncCall;
 class ServiceManager
 {
     /**
-     * @var array
+     * @var CancellationTokenSource[]
      */
-    private $cancellations = [];
+    private array $cancellations = [];
 
     public function __construct(private ServiceProviders $serviceProviders, private LoggerInterface $logger)
     {

--- a/lib/Core/Service/ServiceProviders.php
+++ b/lib/Core/Service/ServiceProviders.php
@@ -17,7 +17,7 @@ final class ServiceProviders implements Countable, IteratorAggregate
     /**
      * @var array<string,ServiceProvider>
      */
-    private $services = [];
+    private array $services = [];
 
     public function __construct(ServiceProvider ...$serviceProviders)
     {

--- a/lib/Core/Workspace/Workspace.php
+++ b/lib/Core/Workspace/Workspace.php
@@ -20,12 +20,12 @@ class Workspace implements Countable, IteratorAggregate
     /**
      * @var TextDocumentItem[]
      */
-    private $documents = [];
+    private array $documents = [];
 
     /**
      * @var array<string,int>
      */
-    private $documentVersions = [];
+    private array $documentVersions = [];
 
     public function __construct(private LoggerInterface $logger = new NullLogger())
     {

--- a/lib/Diagnostics/CodeActionDiagnosticsProvider.php
+++ b/lib/Diagnostics/CodeActionDiagnosticsProvider.php
@@ -16,7 +16,7 @@ class CodeActionDiagnosticsProvider implements DiagnosticsProvider
     /**
      * @var array<CodeActionProvider>
      */
-    private $providers;
+    private array $providers;
 
     public function __construct(CodeActionProvider ...$providers)
     {

--- a/lib/Event/FilesChanged.php
+++ b/lib/Event/FilesChanged.php
@@ -8,15 +8,18 @@ use RuntimeException;
 final class FilesChanged
 {
     /**
-     * @var array
+     * @var FileEvent[]
      */
-    private $events;
+    private array $events = [];
 
     public function __construct(FileEvent ...$events)
     {
         $this->events = $events;
     }
 
+    /**
+     * @return FileEvent[]
+     */
     public function events(): array
     {
         return $this->events;
@@ -24,7 +27,7 @@ final class FilesChanged
 
     public function byType(int $type): self
     {
-        return new self(...array_filter($this->events, function (FileEvent $event) use ($type) {
+        return new self(...array_filter($this->events, function (FileEvent $event) use ($type): bool {
             return $event->type === $type;
         }));
     }

--- a/lib/Example/Diagnostics/SayHelloDiagnosticsProvider.php
+++ b/lib/Example/Diagnostics/SayHelloDiagnosticsProvider.php
@@ -20,7 +20,7 @@ class SayHelloDiagnosticsProvider implements DiagnosticsProvider
     public function provideDiagnostics(TextDocumentItem $textDocument, CancellationToken $cancel): Promise
     {
         /** @phpstan-ignore-next-line */
-        return call(function () {
+        return call(function (): array {
             return [
                 new Diagnostic(
                     new Range(

--- a/lib/LanguageServerBuilder.php
+++ b/lib/LanguageServerBuilder.php
@@ -22,12 +22,9 @@ final class LanguageServerBuilder
     /**
      * @var string|null
      */
-    private $tcpAddress = null;
+    private ?string $tcpAddress = null;
 
-    /**
-     * @var ServerStats|null
-     */
-    private $stats = null;
+    private ?ServerStats $stats = null;
 
     private function __construct(
         private DispatcherFactory $dispatcherFactory,

--- a/lib/LanguageServerTesterBuilder.php
+++ b/lib/LanguageServerTesterBuilder.php
@@ -52,87 +52,54 @@ final class LanguageServerTesterBuilder
     /**
      * @var array<Handler>
      */
-    private $handlers = [];
+    private array $handlers = [];
 
     /**
-     * @var array
+     * @var ServiceProvider[]
      */
-    private $serviceProviders = [];
+    private array $serviceProviders = [];
 
     /**
-     * @var array
+     * @var Command[]
      */
-    private $commands = [];
+    private array $commands = [];
 
-    /**
-     * @var InitializeParams
-     */
-    private $initializeParams;
+    private InitializeParams $initializeParams;
 
-    /**
-     * @var TestMessageTransmitter
-     */
-    private $transmitter;
+    private TestMessageTransmitter $transmitter;
 
-    /**
-     * @var TestResponseWatcher
-     */
-    private $responseWatcher;
+    private TestResponseWatcher $responseWatcher;
 
-    /**
-     * @var bool
-     */
-    private $enableTextDocuments = false;
+    private bool $enableTextDocuments = false;
 
-    /**
-     * @var RpcClient
-     */
-    private $rpcClient;
+    private JsonRpcClient $rpcClient;
 
-    /**
-     * @var ClientApi
-     */
-    private $clientApi;
+    private ClientApi $clientApi;
 
-    /**
-     * @var Workspace
-     */
-    private $workspace;
+    private Workspace $workspace;
 
-    /**
-     * @var bool
-     */
-    private $enableServices = false;
+    private bool $enableServices = false;
 
-    /**
-     * @var bool
-     */
-    private $enableFileEvents = false;
+    private bool $enableFileEvents = false;
 
-    /**
-     * @var bool
-     */
-    private $enableDiagnostics = false;
+    private bool $enableDiagnostics = false;
 
-    /**
-     * @var bool
-     */
-    private $enableCommands = false;
+    private bool $enableCommands = false;
 
     /**
      * @var array<ListenerProviderInterface>
      */
-    private $listeners = [];
+    private array $listeners = [];
 
     /**
      * @var array<DiagnosticsProvider>
      */
-    private $diagnosticsProvider = [];
+    private array $diagnosticsProvider = [];
 
     /**
      * @var string[]
      */
-    private $fileEventGlobs = ['**/*.php'];
+    private array $fileEventGlobs = ['**/*.php'];
 
     private function __construct()
     {
@@ -238,7 +205,7 @@ final class LanguageServerTesterBuilder
     {
         $this->enableFileEvents = true;
 
-        if (null !==$globs) {
+        if (null !== $globs) {
             $this->fileEventGlobs = $globs;
         }
 
@@ -260,7 +227,7 @@ final class LanguageServerTesterBuilder
         $this->enableDiagnostics = true;
         return $this;
     }
-    
+
     public function enableCommands(): self
     {
         $this->enableCommands = true;
@@ -317,9 +284,9 @@ final class LanguageServerTesterBuilder
     private function buildDisapatcherFactory(): DispatcherFactory
     {
         return new ClosureDispatcherFactory(
-            function (MessageTransmitter $transmitter, InitializeParams $params) {
+            function (MessageTransmitter $transmitter, InitializeParams $params): MiddlewareDispatcher {
                 $logger =  new NullLogger();
-                
+
                 $serviceProviders = $this->serviceProviders;
 
                 if ($this->enableDiagnostics) {
@@ -386,11 +353,11 @@ final class LanguageServerTesterBuilder
         if ($this->enableServices) {
             $listeners[] = new ServiceListener($serviceManager);
         }
-        
+
         if ($this->enableTextDocuments) {
             $listeners[] = new WorkspaceListener($this->workspace);
         }
-        
+
         return new AggregateEventDispatcher(...$listeners);
     }
 }

--- a/lib/Listener/DidChangeWatchedFilesListener.php
+++ b/lib/Listener/DidChangeWatchedFilesListener.php
@@ -41,7 +41,7 @@ class DidChangeWatchedFilesListener implements ListenerProviderInterface
                 new Registration(
                     Uuid::uuid4()->__toString(),
                     'workspace/didChangeWatchedFiles',
-                    new DidChangeWatchedFilesRegistrationOptions(array_map(function (string $glob) {
+                    new DidChangeWatchedFilesRegistrationOptions(array_map(function (string $glob): FileSystemWatcher {
                         return new FileSystemWatcher($glob);
                     }, $this->globPatterns))
                 )

--- a/lib/Middleware/InitializeMiddleware.php
+++ b/lib/Middleware/InitializeMiddleware.php
@@ -23,10 +23,7 @@ class InitializeMiddleware implements Middleware
     private const METHOD_INITIALIZED = 'initialized';
     private const METHOD_INITIALIZE = 'initialize';
 
-    /**
-     * @var bool
-     */
-    private $initialized = false;
+    private bool $initialized = false;
 
     /**
      * @param array{name?:string,version?:string} $serverInfo

--- a/lib/Test/LanguageServerTester.php
+++ b/lib/Test/LanguageServerTester.php
@@ -22,10 +22,7 @@ use function Amp\Promise\wait;
 
 final class LanguageServerTester
 {
-    /**
-     * @var Dispatcher
-     */
-    private $dispatcher;
+    private Dispatcher $dispatcher;
 
     public function __construct(
         DispatcherFactory $factory,

--- a/lib/Test/LanguageServerTester/TextDocumentTester.php
+++ b/lib/Test/LanguageServerTester/TextDocumentTester.php
@@ -17,7 +17,7 @@ class TextDocumentTester
     /**
      * @var array<string,int>
      */
-    private static $versions = [];
+    private static array $versions = [];
 
     public function __construct(private LanguageServerTester $tester)
     {

--- a/lib/Test/ListenerProvider/RecordingListenerProvider.php
+++ b/lib/Test/ListenerProvider/RecordingListenerProvider.php
@@ -10,7 +10,7 @@ class RecordingListenerProvider implements ListenerProviderInterface
     /**
      * @var object[]
      */
-    private $recieved = [];
+    private array $recieved = [];
 
     /**
      * {@inheritDoc}

--- a/lib/WorkDoneProgress/ClientCapabilityDependentProgressNotifier.php
+++ b/lib/WorkDoneProgress/ClientCapabilityDependentProgressNotifier.php
@@ -8,10 +8,7 @@ use Phpactor\LanguageServer\Core\Server\ClientApi;
 
 final class ClientCapabilityDependentProgressNotifier implements ProgressNotifier
 {
-    /**
-     * @var ProgressNotifier
-     */
-    private $notifier;
+    private ProgressNotifier $notifier;
 
     public function __construct(ClientApi $api, ClientCapabilities $capabilities)
     {

--- a/lib/WorkDoneProgress/MessageProgressNotifier.php
+++ b/lib/WorkDoneProgress/MessageProgressNotifier.php
@@ -10,10 +10,7 @@ use Phpactor\LanguageServer\Core\Server\Client\MessageClient;
 
 final class MessageProgressNotifier implements ProgressNotifier
 {
-    /**
-     * @var MessageClient
-     */
-    private $api;
+    private MessageClient $api;
 
     public function __construct(ClientApi $api)
     {

--- a/lib/WorkDoneProgress/WorkDoneProgressNotifier.php
+++ b/lib/WorkDoneProgress/WorkDoneProgressNotifier.php
@@ -8,10 +8,7 @@ use Phpactor\LanguageServer\Core\Server\Client\WorkDoneProgressClient;
 
 final class WorkDoneProgressNotifier implements ProgressNotifier
 {
-    /**
-     * @var WorkDoneProgressClient
-     */
-    private $api;
+    private WorkDoneProgressClient $api;
 
     public function __construct(ClientApi $api)
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,7 +6,7 @@ parameters:
 			path: lib/Adapter/DTL/DTLArgumentResolver.php
 
 		-
-			message: "#^Property Phpactor\\\\LanguageServer\\\\Core\\\\Command\\\\CommandDispatcher\\:\\:\\$commandMap type has no value type specified in iterable type array\\.$#"
+			message: "#^Call to an undefined method Phpactor\\\\LanguageServer\\\\Core\\\\Command\\\\Command\\:\\:__invoke\\(\\)\\.$#"
 			count: 1
 			path: lib/Core/Command/CommandDispatcher.php
 
@@ -39,16 +39,6 @@ parameters:
 			message: "#^Method Phpactor\\\\LanguageServer\\\\Core\\\\Dispatcher\\\\ArgumentResolver\\\\PassThroughArgumentResolver\\:\\:resolveArguments\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Core/Dispatcher/ArgumentResolver/PassThroughArgumentResolver.php
-
-		-
-			message: "#^Property Phpactor\\\\LanguageServer\\\\Core\\\\Dispatcher\\\\Dispatcher\\\\MiddlewareDispatcher\\:\\:\\$middleware type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Core/Dispatcher/Dispatcher/MiddlewareDispatcher.php
-
-		-
-			message: "#^Property Phpactor\\\\LanguageServer\\\\Core\\\\Handler\\\\Handlers\\:\\:\\$methods type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Core/Handler/Handlers.php
 
 		-
 			message: "#^Method Phpactor\\\\LanguageServer\\\\Core\\\\Rpc\\\\RawMessage\\:\\:__construct\\(\\) has parameter \\$body with no value type specified in iterable type array\\.$#"
@@ -146,34 +136,9 @@ parameters:
 			path: lib/Core/Server/Transmitter/LspMessageSerializer.php
 
 		-
-			message: "#^Property Phpactor\\\\LanguageServer\\\\Core\\\\Service\\\\ServiceManager\\:\\:\\$cancellations type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Core/Service/ServiceManager.php
-
-		-
-			message: "#^Method Phpactor\\\\LanguageServer\\\\Event\\\\FilesChanged\\:\\:events\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Event/FilesChanged.php
-
-		-
-			message: "#^Property Phpactor\\\\LanguageServer\\\\Event\\\\FilesChanged\\:\\:\\$events type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Event/FilesChanged.php
-
-		-
 			message: "#^Method Phpactor\\\\LanguageServer\\\\Handler\\\\System\\\\ServiceHandler\\:\\:runningServices\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Handler/System/ServiceHandler.php
-
-		-
-			message: "#^Property Phpactor\\\\LanguageServer\\\\LanguageServerTesterBuilder\\:\\:\\$commands type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/LanguageServerTesterBuilder.php
-
-		-
-			message: "#^Property Phpactor\\\\LanguageServer\\\\LanguageServerTesterBuilder\\:\\:\\$serviceProviders type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/LanguageServerTesterBuilder.php
 
 		-
 			message: "#^Method Phpactor\\\\LanguageServer\\\\Listener\\\\DidChangeWatchedFilesListener\\:\\:__construct\\(\\) has parameter \\$globPatterns with no value type specified in iterable type array\\.$#"

--- a/tests/Unit/Core/Handler/HandlerMethodResolverTest.php
+++ b/tests/Unit/Core/Handler/HandlerMethodResolverTest.php
@@ -9,10 +9,7 @@ use RuntimeException;
 
 class HandlerMethodResolverTest extends TestCase
 {
-    /**
-     * @var HandlerMethodResolver
-     */
-    private $resolver;
+    private HandlerMethodResolver $resolver;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Core/Handler/HandlersTest.php
+++ b/tests/Unit/Core/Handler/HandlersTest.php
@@ -6,18 +6,13 @@ use Phpactor\TestUtils\PHPUnit\TestCase;
 use Phpactor\LanguageServer\Core\Handler\Handler;
 use Phpactor\LanguageServer\Core\Handler\HandlerNotFound;
 use Phpactor\LanguageServer\Core\Handler\Handlers;
+use Prophecy\Prophecy\ObjectProphecy;
 
 class HandlersTest extends TestCase
 {
-    /**
-     * @var ObjectProphecy
-     */
-    private $handler1;
+    private ObjectProphecy $handler1;
 
-    /**
-     * @var ObjectProphecy
-     */
-    private $handler2;
+    private ObjectProphecy $handler2;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Core/Server/Parser/LspMessageReaderTest.php
+++ b/tests/Unit/Core/Server/Parser/LspMessageReaderTest.php
@@ -10,11 +10,6 @@ use Phpactor\LanguageServer\Core\Rpc\RawMessage;
 
 class LspMessageReaderTest extends TestCase
 {
-    /**
-     * @var LanguageServerProtocolParser
-     */
-    private $parser;
-
     protected function setUp(): void
     {
     }

--- a/tests/Unit/Core/Service/ServiceManagerTest.php
+++ b/tests/Unit/Core/Service/ServiceManagerTest.php
@@ -10,7 +10,6 @@ use Amp\Promise;
 use Amp\Success;
 use Exception;
 use Generator;
-use Phpactor\LanguageServer\Core\Dispatcher\ArgumentResolver;
 use Phpactor\LanguageServer\Core\Service\ServiceProvider;
 use Phpactor\LanguageServer\Core\Service\ServiceManager;
 use Phpactor\LanguageServer\Core\Service\ServiceProviders;
@@ -22,15 +21,7 @@ class ServiceManagerTest extends AsyncTestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var ArgumentResolver
-     */
-    private $argumentResolver;
-
-    /**
-     * @var TestLogger
-     */
-    private $logger;
+    private TestLogger $logger;
 
     protected function setUp(): void
     {
@@ -153,8 +144,7 @@ class ServiceManagerTest extends AsyncTestCase
 
 class PingService implements ServiceProvider
 {
-    /** @var bool */
-    public $called = false;
+    public bool $called = false;
     public CancellationToken $cancellationToken;
 
     /**

--- a/tests/Unit/Core/Workspace/WorkspaceTest.php
+++ b/tests/Unit/Core/Workspace/WorkspaceTest.php
@@ -12,10 +12,7 @@ use Phpactor\LanguageServer\Core\Workspace\Workspace;
 
 class WorkspaceTest extends TestCase
 {
-    /**
-     * @var Workspace
-     */
-    private $workspace;
+    private Workspace $workspace;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Handler/System/ServiceHandlerTest.php
+++ b/tests/Unit/Handler/System/ServiceHandlerTest.php
@@ -16,22 +16,11 @@ class ServiceHandlerTest extends HandlerTestCase
     /**
      * @var ObjectProphecy<ServiceManager>
      */
-    private $serviceManager;
+    private ObjectProphecy $serviceManager;
 
-    /**
-     * @var ClientApi
-     */
-    private $api;
+    private ClientApi $api;
 
-    /**
-     * @var ServiceHandler
-     */
-    private $serviceHandler;
-
-    /**
-     * @var TestRpcClient
-     */
-    private $client;
+    private TestRpcClient $client;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Handler/System/StatsHandlerTest.php
+++ b/tests/Unit/Handler/System/StatsHandlerTest.php
@@ -13,20 +13,11 @@ use Phpactor\LanguageServer\Tests\Unit\Handler\HandlerTestCase;
 
 class StatsHandlerTest extends HandlerTestCase
 {
-    /**
-     * @var ServerStats
-     */
-    private $stats;
+    private ServerStats $stats;
 
-    /**
-     * @var ClientApi
-     */
-    private $clientApi;
+    private ClientApi $clientApi;
 
-    /**
-     * @var TestRpcClient
-     */
-    private $client;
+    private TestRpcClient $client;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Handler/TextDocument/TextDocumentHandlerTest.php
+++ b/tests/Unit/Handler/TextDocument/TextDocumentHandlerTest.php
@@ -11,7 +11,6 @@ use Phpactor\LanguageServer\Event\TextDocumentOpened;
 use Phpactor\LanguageServer\Event\TextDocumentSaved;
 use Phpactor\LanguageServer\Event\TextDocumentUpdated;
 use Phpactor\LanguageServer\Handler\TextDocument\TextDocumentHandler;
-use Phpactor\LanguageServer\Core\Workspace\Workspace;
 use Phpactor\LanguageServer\Test\ProtocolFactory;
 use Phpactor\LanguageServer\Tests\Unit\Handler\HandlerTestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -23,14 +22,9 @@ class TextDocumentHandlerTest extends HandlerTestCase
     use ProphecyTrait;
 
     /**
-     * @var Workspace
+     * @var ObjectProphecy<EventDispatcherInterface>
      */
-    private $workspace;
-
-    /**
-     * @var ObjectProphecy
-     */
-    private $dispatcher;
+    private ObjectProphecy $dispatcher;
 
     protected function setUp(): void
     {
@@ -48,7 +42,7 @@ class TextDocumentHandlerTest extends HandlerTestCase
     {
         $textDocument = ProtocolFactory::textDocumentItem('foobar', 'foo');
         $this->dispatch('textDocument/didOpen', [
-            'textDocument' => $textDocument
+            'textDocument' => $textDocument,
         ]);
 
         $this->dispatcher->dispatch(new TextDocumentOpened($textDocument))->shouldHaveBeenCalled();
@@ -64,7 +58,7 @@ class TextDocumentHandlerTest extends HandlerTestCase
             'contentChanges' => [
                 [
                     'text' => 'asd',
-                ]
+                ],
             ],
         ]);
 
@@ -75,7 +69,7 @@ class TextDocumentHandlerTest extends HandlerTestCase
     {
         $response = $this->dispatch('textDocument/willSave', [
             'textDocument' => ProtocolFactory::textDocumentIdentifier('foobar'),
-            'reason' => 1
+            'reason' => 1,
         ]);
         self::assertInstanceOf(ResponseMessage::class, $response);
         self::assertNull($response->result);
@@ -91,7 +85,7 @@ class TextDocumentHandlerTest extends HandlerTestCase
             'contentChanges' => [
                 [
                     'text' => 'asd',
-                ]
+                ],
             ],
         ]);
 

--- a/tests/Unit/Listener/DidChangeWatchedFilesListenerTest.php
+++ b/tests/Unit/Listener/DidChangeWatchedFilesListenerTest.php
@@ -17,15 +17,9 @@ use Phpactor\TestUtils\PHPUnit\TestCase;
 
 class DidChangeWatchedFilesListenerTest extends TestCase
 {
-    /**
-     * @var DidChangeWatchedFilesListener
-     */
-    private $listener;
+    private DidChangeWatchedFilesListener $listener;
 
-    /**
-     * @var TestMessageTransmitter
-     */
-    private $transmitter;
+    private TestMessageTransmitter $transmitter;
 
     public function testDynamicallyRegisterIfSupported(): void
     {

--- a/tests/Unit/Listener/ServiceListenerTest.php
+++ b/tests/Unit/Listener/ServiceListenerTest.php
@@ -15,15 +15,12 @@ class ServiceListenerTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var ServiceListener
-     */
-    private $listener;
+    private ServiceListener $listener;
 
     /**
      * @var ObjectProphecy<ServiceManager>
      */
-    private $serviceManager;
+    private ObjectProphecy $serviceManager;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Listener/WorkspaceListenerTest.php
+++ b/tests/Unit/Listener/WorkspaceListenerTest.php
@@ -15,14 +15,11 @@ use Prophecy\Prophecy\ObjectProphecy;
 class WorkspaceListenerTest extends TestCase
 {
     /**
-     * @var Workspace|ObjectProphecy
+     * @var Workspace|ObjectProphecy<Workspace>
      */
-    private $workspace;
+    private Workspace|ObjectProphecy $workspace;
 
-    /**
-     * @var WorkspaceListener
-     */
-    private $listener;
+    private WorkspaceListener $listener;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Middleware/CancellationMiddlewareTest.php
+++ b/tests/Unit/Middleware/CancellationMiddlewareTest.php
@@ -22,7 +22,7 @@ class CancellationMiddlewareTest extends AsyncTestCase
     /**
      * @var ObjectProphecy<MethodRunner>
      */
-    private $runner;
+    private ObjectProphecy $runner;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Middleware/ErrorHandlingMiddlewareTest.php
+++ b/tests/Unit/Middleware/ErrorHandlingMiddlewareTest.php
@@ -20,10 +20,7 @@ use RuntimeException;
 
 class ErrorHandlingMiddlewareTest extends AsyncTestCase
 {
-    /**
-     * @var TestLogger
-     */
-    private $logger;
+    private TestLogger $logger;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Middleware/InitializeMiddlewareTest.php
+++ b/tests/Unit/Middleware/InitializeMiddlewareTest.php
@@ -29,7 +29,7 @@ class InitializeMiddlewareTest extends AsyncTestCase
     /**
      * @var ObjectProphecy<EventDispatcherInterface>
      */
-    private $dispatcher;
+    private ObjectProphecy $dispatcher;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Middleware/ResponseHandlingMiddlewareTest.php
+++ b/tests/Unit/Middleware/ResponseHandlingMiddlewareTest.php
@@ -15,10 +15,7 @@ use Phpactor\LanguageServer\Middleware\ResponseHandlingMiddleware;
 
 class ResponseHandlingMiddlewareTest extends AsyncTestCase
 {
-    /**
-     * @var ResponseWatcher
-     */
-    private $watcher;
+    private ResponseWatcher $watcher;
 
     protected function setUp(): void
     {

--- a/tests/Unit/WorkDoneProgress/ClientCapabilityDependentProgressNotifierTest.php
+++ b/tests/Unit/WorkDoneProgress/ClientCapabilityDependentProgressNotifierTest.php
@@ -13,15 +13,9 @@ use Phpactor\LanguageServer\WorkDoneProgress\WorkDoneToken;
 
 final class ClientCapabilityDependentProgressNotifierTest extends AsyncTestCase
 {
-    /**
-     * @var TestRpcClient
-     */
-    private $client;
+    private TestRpcClient $client;
 
-    /**
-     * @var TestMessageTransmitter
-     */
-    private $transmitter;
+    private TestMessageTransmitter $transmitter;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
It's mostly docblock to built-in type conversion. 

Some unused private properties were removed from test classes.