### PR TITLE
Require socket v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "amphp/socket": "^1.1",
+        "amphp/socket": "^2.3",
         "dantleech/argument-resolver": "^1.1",
         "dantleech/invoke": "^2.0",
         "phpactor/language-server-protocol": "^3.17.5",


### PR DESCRIPTION
Socket v1 gives a warning
`Package league/uri-parser is abandoned, you should avoid using it. Use league/uri-interfaces instead.`

From what I read the usage of socket here is compatible with version 2