### PR TITLE
Fix leak in HandlerMethodRunner::$cancellations

### DIFF
--- a/lib/Core/Handler/HandlerMethodRunner.php
+++ b/lib/Core/Handler/HandlerMethodRunner.php
@@ -56,25 +56,31 @@ final class HandlerMethodRunner implements MethodRunner
                 $this->cancellations[$request->id] = $cancellationTokenSource;
             }
 
-            $args = array_values($this->argumentResolver->resolveArguments($handler, $method, $request));
-            $args[] = $cancellationTokenSource->getToken();
+            try {
+                $args = array_values($this->argumentResolver->resolveArguments($handler, $method, $request));
+                $args[] = $cancellationTokenSource->getToken();
 
-            $promise = $handler->$method(...$args) ?? new Success(null);
+                $promise = $handler->$method(...$args) ?? new Success(null);
 
-            if (!$promise instanceof Promise) {
-                throw new RuntimeException(sprintf(
-                    'Handler "%s:%s" must return instance of Amp\\Promise, got "%s"',
-                    $handler::class,
-                    $method,
-                    get_debug_type($promise)
-                ));
+                if (!$promise instanceof Promise) {
+                    throw new RuntimeException(sprintf(
+                        'Handler "%s:%s" must return instance of Amp\\Promise, got "%s"',
+                        $handler::class,
+                        $method,
+                        get_debug_type($promise)
+                    ));
+                }
+
+                if (!$request instanceof RequestMessage) {
+                    return null;
+                }
+
+                return new ResponseMessage($request->id, yield $promise);
+            } finally {
+                if ($request instanceof RequestMessage) {
+                    unset($this->cancellations[$request->id]);
+                }
             }
-
-            if (!$request instanceof RequestMessage) {
-                return null;
-            }
-
-            return new ResponseMessage($request->id, yield $promise);
         });
     }
 

--- a/tests/Unit/Core/Handler/HandlerMethodRunnerTest.php
+++ b/tests/Unit/Core/Handler/HandlerMethodRunnerTest.php
@@ -4,6 +4,7 @@ namespace Phpactor\LanguageServer\Tests\Unit\Core\Handler;
 
 use Amp\CancellationToken;
 use Amp\CancelledException;
+use Amp\Failure;
 use Amp\PHPUnit\AsyncTestCase;
 use Amp\Success;
 use Phpactor\LanguageServer\Core\Handler\ClosureHandler;
@@ -12,6 +13,7 @@ use Phpactor\LanguageServer\Core\Handler\Handlers;
 use Phpactor\LanguageServer\Core\Rpc\NotificationMessage;
 use Phpactor\LanguageServer\Core\Rpc\RequestMessage;
 use Phpactor\LanguageServer\Core\Rpc\ResponseMessage;
+use ReflectionObject;
 use RuntimeException;
 use function Amp\call;
 use function Amp\delay;
@@ -121,10 +123,78 @@ class HandlerMethodRunnerTest extends AsyncTestCase
         yield $promise;
     }
 
+    public function testCancellationsIsEmptyAfterSuccessfulDispatch()
+    {
+        $runner = $this->createRunner([
+            new ClosureHandler('foobar', function (): Success {
+                return new Success('done');
+            }),
+        ]);
+
+        yield $runner->dispatch(
+            new RequestMessage(1, 'foobar', [])
+        );
+
+        self::assertSame([], $this->cancellationsOf($runner));
+    }
+
+    public function testCancellationsIsEmptyAfterHandlerThrows()
+    {
+        $runner = $this->createRunner([
+            new ClosureHandler('foobar', function () {
+                return new Failure(new RuntimeException('foobar'));
+            }),
+        ]);
+
+        try {
+            yield $runner->dispatch(new RequestMessage(42, 'foobar', []));
+            self::fail('expected handler exception to propagate');
+        } catch (RuntimeException $e) {
+            // expected
+        }
+
+        self::assertSame([], $this->cancellationsOf($runner));
+    }
+
+    public function testCancellationsIsEmptyAfterCancel()
+    {
+        $runner = $this->createRunner([
+            new ClosureHandler('foobar', function (CancellationToken $token) {
+                return call(function () use ($token) {
+                    yield delay(50);
+                    $token->throwIfRequested();
+                });
+            }),
+        ]);
+
+        $promise = $runner->dispatch(new RequestMessage(7, 'foobar', []));
+        $runner->cancelRequest(7);
+
+        try {
+            yield $promise;
+            self::fail('expected CancelledException');
+        } catch (CancelledException $e) {
+            // expected
+        }
+
+        self::assertSame([], $this->cancellationsOf($runner));
+    }
+
     private function createRunner(array $handlers): HandlerMethodRunner
     {
         return new HandlerMethodRunner(
             new Handlers(...$handlers)
         );
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    private function cancellationsOf(HandlerMethodRunner $runner): array
+    {
+        return (new ReflectionObject($runner))
+            ->getProperty('cancellations')
+            ->getValue($runner)
+        ;
     }
 }


### PR DESCRIPTION
`HandlerMethodRunner::dispatch()` inserted a CancellationTokenSource per RequestMessage but never unset the entry.

Found this while testing [reliforp/reli-prof](https://github.com/reliforp/reli-prof) (a PHP memory profiler I work on) against a Phpactor instance. The heap-snapshot diffing surfaced an unbounded accumulation of Amp\CancellationTokenSource indexed by LSP request id, which traced back to this dispatch path.

This fixes zed-industries/zed#57121.
